### PR TITLE
Allow users to comment out ext_dem_file and ext_wbm_file in config.ini

### DIFF
--- a/S1_NRB/ancillary.py
+++ b/S1_NRB/ancillary.py
@@ -334,8 +334,8 @@ def _log_process_config(logger, config):
     tmp_dir = {config['tmp_dir']}
     db_file = {config['db_file']}
     kml_file = {config['kml_file']}
-    ext_dem_file = {config['ext_dem_file']}
-    ext_wbm_file = {config['ext_wbm_file']}
+    ext_dem_file = {config.get('ext_dem_file')}
+    ext_wbm_file = {config.get('ext_wbm_file')}
     ====================================================================================================================
     SOFTWARE
     

--- a/S1_NRB/config.py
+++ b/S1_NRB/config.py
@@ -133,9 +133,9 @@ def geocode_params(config):
     return {'tr': {'IW': 10,
                    'SM': 10,
                    'EW': 20}[config['acq_mode']],
-            'demName': {'IW': 'Copernicus 30m Global DEM' if config['ext_dem_file'] is None else
+            'demName': {'IW': 'Copernicus 30m Global DEM' if config.get('ext_dem_file') is None else
                               'Copernicus 10m EEA DEM',
-                        'SM': 'Copernicus 30m Global DEM' if config['ext_dem_file'] is None else
+                        'SM': 'Copernicus 30m Global DEM' if config.get('ext_dem_file') is None else
                               'Copernicus 10m EEA DEM',
                         'EW': 'GETASSE30'}[config['acq_mode']],
             'scaling': 'linear',

--- a/S1_NRB/processor.py
+++ b/S1_NRB/processor.py
@@ -313,7 +313,7 @@ def main(config_file, section_name):
             try:
                 geocode(infile=scene, outdir=config['out_dir'], t_srs=epsg, tmpdir=config['tmp_dir'],
                         standardGridOriginX=align_dict['xmax'], standardGridOriginY=align_dict['ymin'],
-                        externalDEMFile=config['ext_dem_file'], **geocode_prms)
+                        externalDEMFile=config.get('ext_dem_file'), **geocode_prms)
                 
                 t = round((time.time() - start_time), 2)
                 log.info('[GEOCODE] -- {scene} -- {time}'.format(scene=scene, time=t))
@@ -329,7 +329,7 @@ def main(config_file, section_name):
             try:
                 noise_power(infile=scene, outdir=config['out_dir'], polarizations=['VV', 'VH'],
                             spacing=geocode_prms['tr'], t_srs=epsg, refarea='gamma0', tmpdir=config['tmp_dir'],
-                            demName=geocode_prms['demName'], externalDEMFile=config['ext_dem_file'],
+                            demName=geocode_prms['demName'], externalDEMFile=config.get('ext_dem_file'),
                             externalDEMApplyEGM=geocode_prms['externalDEMApplyEGM'],
                             alignToStandardGrid=geocode_prms['alignToStandardGrid'],
                             standardGridOriginX=align_dict['xmax'], standardGridOriginY=align_dict['ymin'],
@@ -358,7 +358,7 @@ def main(config_file, section_name):
                 start_time = time.time()
                 try:
                     nrb_processing(scenes=scenes, outdir=outdir, tile=tile, extent=geo_dict[tile]['ext'],
-                                   epsg=epsg, external_wbm=config['ext_wbm_file'], dem_name=geocode_prms['demName'])
+                                   epsg=epsg, external_wbm=config.get('ext_wbm_file'), dem_name=geocode_prms['demName'])
                     log.info('[    NRB] -- {scenes} -- {time}'.format(scenes=scenes,
                                                                       time=round((time.time() - start_time), 2)))
                 except Exception as e:


### PR DESCRIPTION
I currently use the software without preparing a specific external dem file and external water body mask file. I have commented out both variables in the `config.ini`, but this led to errors (key does not exist). 

Thus, I changed `config['ext_dem_file']` and `config['ext_wbm_file']` to `config.get('ext_dem_file')` and `config.get('ext_wbm_file')`. 

If the value is not available in `config.ini` the value `None` is returned.