### PR TITLE
[ancilliary] add raster properties if no wbm is used

### DIFF
--- a/S1_NRB/ancillary.py
+++ b/S1_NRB/ancillary.py
@@ -206,6 +206,10 @@ def modify_data_mask(dm_path, extent, epsg, driver, creation_opt, overviews, mul
     else:
         with Raster(dm_path) as ras_dm:
             mask_arr = ras_dm.array()
+            rows = ras_dm.rows
+            cols = ras_dm.cols
+            geotrans = ras_dm.raster.GetGeoTransform()
+            proj = ras_dm.raster.GetProjection()
         dm_bands.pop(4)
     
     # MULTI-LAYER COG


### PR DESCRIPTION
I currently use the software without a water body mask. However, the post-processing (NRB packaging) fails with the following message: 
`local variable 'rows' referenced before assignment`

I had a look at the source code and found the following line, which needs the `rows` variable. This and other variables (cols, proj, geotrans) are only set in the if clause before when a water body mask is available