### PR TITLE
store DEM/WBM tiles in UTM zones different to the native MGRS zone

### DIFF
--- a/S1_NRB/config.py
+++ b/S1_NRB/config.py
@@ -30,7 +30,8 @@ def get_config(config_file, section_name='GENERAL'):
     
     allowed_keys = ['mode', 'aoi_tiles', 'aoi_geometry', 'mindate', 'maxdate', 'acq_mode',
                     'work_dir', 'scene_dir', 'rtc_dir', 'tmp_dir', 'dem_dir', 'wbm_dir',
-                    'db_file', 'kml_file', 'dem_type', 'gdal_threads', 'log_dir', 'nrb_dir']
+                    'db_file', 'kml_file', 'dem_type', 'gdal_threads', 'log_dir', 'nrb_dir',
+                    'etad', 'etad_dir']
     out_dict = {}
     for k, v in parser_sec.items():
         if k not in allowed_keys:

--- a/S1_NRB/config.py
+++ b/S1_NRB/config.py
@@ -74,6 +74,14 @@ def get_config(config_file, section_name='GENERAL'):
             allowed = ['Copernicus 10m EEA DEM', 'Copernicus 30m Global DEM II',
                        'Copernicus 30m Global DEM', 'GETASSE30']
             assert v in allowed, "Parameter '{}': expected to be one of {}; got '{}' instead".format(k, allowed, v)
+        if k == 'etad':
+            if v.lower() == 'true':
+                v = True
+            elif v.lower() == 'false':
+                v = False
+            else:
+                allowed = ['True', 'true', 'False', 'false']
+                raise ValueError("Parameter '{}': expected to be one of {}; got '{}' instead".format(k, allowed, v))
         out_dict[k] = v
     
     assert any([out_dict[k] is not None for k in ['aoi_tiles', 'aoi_geometry']])

--- a/S1_NRB/processor.py
+++ b/S1_NRB/processor.py
@@ -1,7 +1,10 @@
+import shutil
+
 import os
 import re
 import time
 import tempfile
+import tarfile as tf
 from getpass import getpass
 from datetime import datetime, timezone
 from lxml import etree
@@ -10,7 +13,7 @@ from osgeo import gdal
 from spatialist import Raster, Vector, vectorize, boundary, bbox, intersect, rasterize
 from spatialist.ancillary import finder
 from spatialist.auxil import gdalwarp, gdalbuildvrt
-from pyroSAR import identify_many, Archive
+from pyroSAR import identify, identify_many, Archive
 from pyroSAR.snap.util import geocode, noise_power
 from pyroSAR.ancillary import groupbyTime, seconds, find_datasets
 from pyroSAR.auxdata import dem_autoload, dem_create
@@ -19,6 +22,7 @@ import S1_NRB.ancillary as ancil
 import S1_NRB.tile_extraction as tile_ex
 from S1_NRB.metadata import extract, xmlparser, stacparser
 from S1_NRB.metadata.mapping import ITEM_MAP
+from s1etad_tools.cli.slc_correct import s1etad_slc_correct_main
 
 gdal.UseExceptions()
 
@@ -436,19 +440,23 @@ def main(config_file, section_name, debug=False):
             ex_dem_nodata = None
     
     ####################################################################################################################
-    # geocode & noise power - SNAP processing
+    # SNAP RTC processing
     np_dict = {'sigma0': 'NESZ', 'beta0': 'NEBZ', 'gamma0': 'NEGZ'}
     np_refarea = 'sigma0'
     
     if snap_flag:
         for i, scene in enumerate(ids):
+            ###############################################
+            # DEM preparation
             dem_buffer = 200  # meters
             scene_base = os.path.splitext(os.path.basename(scene.scene))[0]
-            out_dir_scene = os.path.join(config['rtc_dir'], scene_base, str(epsg))
-            tmp_dir_scene = os.path.join(config['tmp_dir'], scene_base, str(epsg))
-            os.makedirs(out_dir_scene, exist_ok=True)
-            os.makedirs(tmp_dir_scene, exist_ok=True)
-            fname_dem = os.path.join(tmp_dir_scene, scene.outname_base() + '_DEM_{}.tif'.format(epsg))
+            out_dir_scene = os.path.join(config['rtc_dir'], scene_base)
+            tmp_dir_scene = os.path.join(config['tmp_dir'], scene_base)
+            out_dir_scene_epsg = os.path.join(out_dir_scene, str(epsg))
+            tmp_dir_scene_epsg = os.path.join(tmp_dir_scene, str(epsg))
+            os.makedirs(out_dir_scene_epsg, exist_ok=True)
+            os.makedirs(tmp_dir_scene_epsg, exist_ok=True)
+            fname_dem = os.path.join(tmp_dir_scene_epsg, scene.outname_base() + '_DEM_{}.tif'.format(epsg))
             if not os.path.isfile(fname_dem):
                 with scene.geometry() as footprint:
                     footprint.reproject(epsg)
@@ -460,15 +468,51 @@ def main(config_file, section_name, debug=False):
                     with bbox(extent, epsg) as dem_box:
                         with Raster(dem_names[i], list_separate=False)[dem_box] as dem_mosaic:
                             dem_mosaic.write(fname_dem, format='GTiff')
-            
-            list_processed = finder(out_dir_scene, ['*'])
+            ###############################################
+            # ETAD correction
+            if config['etad']:
+                print('###### [   ETAD] Scene {s}/{s_total}: {scene}'.format(s=i + 1, s_total=len(ids),
+                                                                             scene=scene.scene))
+                slc_corrected_dir = os.path.join(tmp_dir_scene, 'SLC_etad')
+                os.makedirs(slc_corrected_dir, exist_ok=True)
+                slc_base = os.path.basename(scene.scene).replace('.zip', '.SAFE')
+                slc_corrected = os.path.join(slc_corrected_dir, slc_base)
+                if not os.path.isdir(slc_corrected):
+                    acqtime = re.findall('[0-9T]{15}', os.path.basename(scene.scene))
+                    result = finder(config['etad_dir'], ['_'.join(acqtime)], regex=True)
+                    if len(result) > 0:
+                        if result[0].endswith('.tar'):
+                            etad_base = os.path.basename(result[0]).replace('.tar', '.SAFE')
+                            etad = os.path.join(tmp_dir_scene, etad_base)
+                            if not os.path.isdir(etad):
+                                archive = tf.open(result[0], 'r')
+                                archive.extractall(tmp_dir_scene)
+                                archive.close()
+                        elif result[0].endswith('SAFE'):
+                            etad = result[0]
+                        else:
+                            raise RuntimeError('ETAD products are required to be .tar archives or .SAFE folders')
+                        scene.unpack(os.path.join(tmp_dir_scene, 'SLC_original'), exist_ok=True)
+                        s1etad_slc_correct_main(s1_product=scene.scene,
+                                                etad_product=etad,
+                                                outdir=slc_corrected_dir,
+                                                nthreads=2)
+                        shutil.rmtree(os.path.join(tmp_dir_scene, 'SLC_original'))
+                    else:
+                        raise RuntimeError('cannot find ETAD product for scene {}'.format(scene.scene))
+                else:
+                    msg = 'Already processed - Skip!'
+                    print('### ' + msg)
+                scene = identify(slc_corrected)
+            ###############################################
+            list_processed = finder(out_dir_scene_epsg, ['*'])
             exclude = list(np_dict.values())
             print('###### [GEOCODE] Scene {s}/{s_total}: {scene}'.format(s=i + 1, s_total=len(ids),
                                                                          scene=scene.scene))
             if len([item for item in list_processed if not any(ex in item for ex in exclude)]) < 4:
                 start_time = time.time()
                 try:
-                    geocode(infile=scene, outdir=out_dir_scene, t_srs=epsg, tmpdir=tmp_dir_scene,
+                    geocode(infile=scene, outdir=out_dir_scene_epsg, t_srs=epsg, tmpdir=tmp_dir_scene_epsg,
                             standardGridOriginX=align_dict['xmax'], standardGridOriginY=align_dict['ymin'],
                             externalDEMFile=fname_dem, externalDEMNoDataValue=ex_dem_nodata, **geocode_prms)
                     
@@ -484,14 +528,14 @@ def main(config_file, section_name, debug=False):
                 msg = 'Already processed - Skip!'
                 print('### ' + msg)
                 log.info('[GEOCODE] -- {scene} -- {msg}'.format(scene=scene.scene, msg=msg))
-            
+            ###############################################
             print('###### [NOISE_P] Scene {s}/{s_total}: {scene}'.format(s=i + 1, s_total=len(ids),
                                                                          scene=scene.scene))
             if len([item for item in list_processed if np_dict[np_refarea] in item]) == 0:
                 start_time = time.time()
                 try:
-                    noise_power(infile=scene.scene, outdir=out_dir_scene, polarizations=scene.polarizations,
-                                spacing=geocode_prms['spacing'], refarea=np_refarea, tmpdir=tmp_dir_scene,
+                    noise_power(infile=scene.scene, outdir=out_dir_scene_epsg, polarizations=scene.polarizations,
+                                spacing=geocode_prms['spacing'], refarea=np_refarea, tmpdir=tmp_dir_scene_epsg,
                                 externalDEMFile=fname_dem, externalDEMNoDataValue=ex_dem_nodata, t_srs=epsg,
                                 externalDEMApplyEGM=geocode_prms['externalDEMApplyEGM'],
                                 alignToStandardGrid=geocode_prms['alignToStandardGrid'],

--- a/S1_NRB/processor.py
+++ b/S1_NRB/processor.py
@@ -354,7 +354,8 @@ def prepare_dem(geometries, config, threads, spacing, epsg=None):
     dem_names = []
     for geo in geometries:
         dem_names_scene = []
-        tiles = tile_ex.tiles_from_aoi(vectorobject=geo, kml=config['kml_file'], epsg=epsg)
+        tiles = tile_ex.tiles_from_aoi(vectorobject=geo, kml=config['kml_file'],
+                                       epsg=epsg, strict=False)
         print('### creating DEM tiles: \n{tiles}'.format(tiles=tiles))
         for i, tilename in enumerate(tiles):
             dem_tile = os.path.join(dem_dir, '{}_DEM.tif'.format(tilename))

--- a/config.ini
+++ b/config.ini
@@ -57,7 +57,8 @@ gdal_threads = 4
 
 # Extended Timing Annotation Dataset (ETAD) correction
 # https://sentinel.esa.int/web/sentinel/missions/sentinel-1/data-products/etad-dataset
-# If etad==True, etad_dir is searched for ETAD products matching the respective input SLC
-# and a new SLC is created in tmp_dir, which is then used for all other processing steps.
+# If [etad] is True, [etad_dir] is searched for ETAD products matching the respective input SLC
+# and a new SLC is created in [tmp_dir], which is then used for all other processing steps.
+# If [etad] is False, [etad_dir] will be ignored.
 etad = False
 etad_dir = /example/etad/directory

--- a/config.ini
+++ b/config.ini
@@ -54,3 +54,10 @@ dem_type = Copernicus 30m Global DEM II
 
 # Temporarily changes GDAL_NUM_THREADS during processing. Will be reset after processing has finished.
 gdal_threads = 4
+
+# Extended Timing Annotation Dataset (ETAD) correction
+# https://sentinel.esa.int/web/sentinel/missions/sentinel-1/data-products/etad-dataset
+# If etad==True, etad_dir is searched for ETAD products matching the respective input SLC
+# and a new SLC is created in tmp_dir, which is then used for all other processing steps.
+etad = False
+etad_dir = /example/etad/directory

--- a/environment.yaml
+++ b/environment.yaml
@@ -11,3 +11,6 @@ dependencies:
   - pystac
   - scipy
   - pyroSAR>=0.16.2
+  - pip:
+      - s1etad @ git+https://gitlab.com/s1-etad/s1-etad.git
+      - s1etad_tools @ git+https://gitlab.com/s1-etad/sandbox-etad-slc-correction.git

--- a/environment.yaml
+++ b/environment.yaml
@@ -2,6 +2,7 @@ name: nrb_env
 channels:
   - conda-forge
   - defaults
+  - s1-etad
 dependencies:
   - python>=3.8
   - gdal>=3.4.1
@@ -11,6 +12,5 @@ dependencies:
   - pystac
   - scipy
   - pyroSAR>=0.16.2
-  - pip:
-      - s1etad @ git+https://gitlab.com/s1-etad/s1-etad.git
-      - s1etad_tools @ git+https://gitlab.com/s1-etad/sandbox-etad-slc-correction.git
+  - s1etad>=0.5.3
+  - s1etad_tools>=0.8.1

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,9 @@ setup(
                       'lxml',
                       'pystac',
                       'pyroSAR>=0.16.2',
-                      'scipy'],
+                      'scipy',
+                      's1etad @ git+https://gitlab.com/s1-etad/s1-etad.git',
+                      's1etad_tools @ git+https://gitlab.com/s1-etad/sandbox-etad-slc-correction.git'],
     python_requires='>=3.8',
     zip_safe=False,
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,7 @@ setup(
                       'pystac',
                       'pyroSAR>=0.16.2',
                       'scipy',
-                      's1etad @ git+https://gitlab.com/s1-etad/s1-etad.git',
-                      's1etad_tools @ git+https://gitlab.com/s1-etad/sandbox-etad-slc-correction.git'],
+                      's1etad>=0.5.3'],
     python_requires='>=3.8',
     zip_safe=False,
     entry_points={


### PR DESCRIPTION
In order to ensure full coverage of prepared DEM tiles in the target projection it is necessary to reproject tiles into a UTM zone different to that of the native MGRS tile. For example, the DEM tile `33TVN` over Austria might have to exist in zone 32N (EPSG:32632), although its native projection is 33N (EPSG:32633). Previously the processor would only cover the extent of MGRS tiles with the target projection (thanks @maawoo for the figure):

![Screenshot from 2022-03-25 10-47-39](https://user-images.githubusercontent.com/56583917/160096942-82660a67-a061-4553-bb17-4c08950b2f0a.png)
(footprints of two SLCs overlapping with tiles of UTM zone 32N, their scene-specific DEM coverage, and an exemplary S1-NRB backscatter tile. The scenes are cut along the edge of MGRS tiles in UTM zone 32N)

With this the processor is able to handle tile IDs with a suffix containing the EPSG code, e.g. `33TVN_32632`, and thus ensure full DEM coverage of respective SLCs during processing.