### PR TITLE
extended acquisition mode support

### DIFF
--- a/S1_NRB/config.py
+++ b/S1_NRB/config.py
@@ -159,13 +159,7 @@ def geocode_conf(config):
             'clean_edges': True,
             'clean_edges_npixels': 4,
             'test': False,
-            'cleanup': True,
-            'rlks': {'IW': 5,
-                     'SM': 6,
-                     'EW': 3}[config['acq_mode']],
-            'azlks': {'IW': 1,
-                      'SM': 6,
-                      'EW': 1}[config['acq_mode']]}
+            'cleanup': True}
 
 
 def gdal_conf(config):

--- a/S1_NRB/config.py
+++ b/S1_NRB/config.py
@@ -31,7 +31,7 @@ def get_config(config_file, section_name='GENERAL'):
     allowed_keys = ['mode', 'aoi_tiles', 'aoi_geometry', 'mindate', 'maxdate', 'acq_mode',
                     'work_dir', 'scene_dir', 'rtc_dir', 'tmp_dir', 'dem_dir', 'wbm_dir',
                     'db_file', 'kml_file', 'dem_type', 'gdal_threads', 'log_dir', 'nrb_dir',
-                    'etad', 'etad_dir']
+                    'etad', 'etad_dir', 'product']
     out_dict = {}
     for k, v in parser_sec.items():
         if k not in allowed_keys:
@@ -87,6 +87,9 @@ def get_config(config_file, section_name='GENERAL'):
             else:
                 allowed = ['True', 'true', 'False', 'false']
                 raise ValueError("Parameter '{}': expected to be one of {}; got '{}' instead".format(k, allowed, v))
+        if k == 'product':
+            allowed = ['GRD', 'SLC']
+            assert v in allowed, "Parameter '{}': expected to be one of {}; got '{}' instead".format(k, allowed, v)
         out_dict[k] = v
     
     assert any([out_dict[k] is not None for k in ['aoi_tiles', 'aoi_geometry']])

--- a/S1_NRB/config.py
+++ b/S1_NRB/config.py
@@ -55,7 +55,10 @@ def get_config(config_file, section_name='GENERAL'):
             assert v in ['IW', 'EW', 'SM']
         if k == 'work_dir':
             assert os.path.isdir(v), "Parameter '{}': '{}' must be an existing directory".format(k, v)
-        if k.endswith('_dir') and not k == 'work_dir':
+        dir_ignore = ['work_dir']
+        if parser_sec['etad'] == 'False':
+            dir_ignore.append('etad_dir')
+        if k.endswith('_dir') and k not in dir_ignore:
             if any(x in v for x in ['/', '\\']):
                 assert os.path.isdir(v), "Parameter '{}': {} is a full path to a non-existing directory".format(k, v)
             else:

--- a/S1_NRB/metadata/extract.py
+++ b/S1_NRB/metadata/extract.py
@@ -408,7 +408,7 @@ def _get_block_offset(band):
     return 0
 
 
-def meta_dict(config, target, src_ids, snap_datasets, proc_time, start, stop, compression):
+def meta_dict(target, src_ids, snap_datasets, dem_type, proc_time, start, stop, compression):
     """
     Creates a dictionary containing metadata for a product scene, as well as its source scenes. The dictionary can then
     be utilized by `metadata.xmlparser` and `metadata.stacparser` to generate XML and STAC JSON metadata files,
@@ -416,8 +416,6 @@ def meta_dict(config, target, src_ids, snap_datasets, proc_time, start, stop, co
     
     Parameters
     ----------
-    config: dict
-        Dictionary of the parsed config parameters for the current process.
     target: str
         A path pointing to the NRB product scene being created.
     src_ids: list[ID]
@@ -425,6 +423,8 @@ def meta_dict(config, target, src_ids, snap_datasets, proc_time, start, stop, co
     snap_datasets: list[str]
         List of output files processed with `pyroSAR.snap.util.geocode` that match the source SLC scenes that overlap
         with the current MGRS tile.
+    dem_type: str
+        The DEM type used for processing.
     proc_time: datetime.datetime
         The datetime object used to generate the unique product identifier from.
     start: str
@@ -459,11 +459,11 @@ def meta_dict(config, target, src_ids, snap_datasets, proc_time, start, stop, co
     stac_bbox, stac_geometry = convert_coordinates(coords=prod_meta['extent_4326'], stac=True)
     stac_bbox_native = convert_coordinates(coords=prod_meta['extent'], stac=True)[0]
     
-    dem_access = DEM_MAP[config['dem_type']]['access']
-    dem_ref = DEM_MAP[config['dem_type']]['ref']
-    dem_type = DEM_MAP[config['dem_type']]['type']
-    egm_ref = DEM_MAP[config['dem_type']]['egm']
-    dem_name = config['dem_type'].replace(' II', '')
+    dem_access = DEM_MAP[dem_type]['access']
+    dem_ref = DEM_MAP[dem_type]['ref']
+    dem_subtype = DEM_MAP[dem_type]['type']
+    egm_ref = DEM_MAP[dem_type]['egm']
+    dem_name = dem_type.replace(' II', '')
     
     tups = [(ITEM_MAP[key]['suffix'], ITEM_MAP[key]['z_error']) for key in ITEM_MAP.keys()]
     z_err_dict = dict(tups)
@@ -516,7 +516,7 @@ def meta_dict(config, target, src_ids, snap_datasets, proc_time, start, stop, co
     meta['prod']['demName'] = dem_name
     meta['prod']['demReference'] = dem_ref
     meta['prod']['demResamplingMethod'] = 'bilinear'
-    meta['prod']['demType'] = dem_type
+    meta['prod']['demType'] = dem_subtype
     meta['prod']['demAccess'] = dem_access
     meta['prod']['doi'] = None
     meta['prod']['ellipsoidalHeight'] = None

--- a/S1_NRB/metadata/extract.py
+++ b/S1_NRB/metadata/extract.py
@@ -426,11 +426,11 @@ def meta_dict(target, src_ids, snap_datasets, dem_type, proc_time, start, stop, 
     dem_type: str
         The DEM type used for processing.
     proc_time: datetime.datetime
-        The datetime object used to generate the unique product identifier from.
-    start: str
-        The product start time as a string in the format: YYYYmmddTHHMMSS
-    stop: str
-        The product stop time as a string in the format: YYYYmmddTHHMMSS
+        The processing time object used to generate the unique product identifier.
+    start: datetime.datetime
+        The product start time.
+    stop: datetime.datetime
+        The product stop time.
     compression: str
         The compression type applied to raster files of the product.
     
@@ -566,8 +566,8 @@ def meta_dict(target, src_ids, snap_datasets, dem_type, proc_time, start, stop, 
     meta['prod']['RTCAlgorithm'] = 'https://doi.org/10.1109/Tgrs.2011.2120616'
     meta['prod']['status'] = 'PLANNED'
     meta['prod']['timeCreated'] = proc_time
-    meta['prod']['timeStart'] = datetime.strptime(start, '%Y%m%dT%H%M%S')
-    meta['prod']['timeStop'] = datetime.strptime(stop, '%Y%m%dT%H%M%S')
+    meta['prod']['timeStart'] = start
+    meta['prod']['timeStop'] = stop
     meta['prod']['transform'] = prod_meta['transform']
     
     # Source metadata

--- a/S1_NRB/metadata/extract.py
+++ b/S1_NRB/metadata/extract.py
@@ -608,18 +608,25 @@ def meta_dict(config, target, src_ids, snap_datasets, proc_time, start, stop, co
                                            out_type='float')
         res_rg, res_az = src_sid[uid].resolution()
         
+        def read_manifest(pattern, attrib=None):
+            obj = src_xml[uid]['manifest'].find(pattern, nsmap)
+            if attrib is not None:
+                return obj.attrib[attrib]
+            else:
+                return obj.text
+        
         # (sorted alphabetically)
         meta['source'][uid] = {}
         meta['source'][uid]['access'] = 'https://scihub.copernicus.eu'
         meta['source'][uid]['acquisitionType'] = 'NOMINAL'
-        meta['source'][uid]['ascendingNodeDate'] = src_xml[uid]['manifest'].find('.//s1:ascendingNodeTime', nsmap).text
+        meta['source'][uid]['ascendingNodeDate'] = read_manifest('.//s1:ascendingNodeTime')
         meta['source'][uid]['azimuthLookBandwidth'] = az_look_bandwidth
         meta['source'][uid]['azimuthNumberOfLooks'] = az_num_looks
         meta['source'][uid]['azimuthPixelSpacing'] = str(sum(list(az_px_spacing.values())) /
                                                          len(list(az_px_spacing.values())))
         meta['source'][uid]['azimuthResolution'] = str(res_az)
         meta['source'][uid]['dataGeometry'] = 'slant range'
-        meta['source'][uid]['datatakeID'] = src_xml[uid]['manifest'].find('.//s1sarl1:missionDataTakeID', nsmap).text
+        meta['source'][uid]['datatakeID'] = read_manifest('.//s1sarl1:missionDataTakeID')
         url = 'https://sentinel.esa.int/documents/247904/1877131/Sentinel-1-Product-Specification'
         meta['source'][uid]['doi'] = url
         meta['source'][uid]['faradayMeanRotationAngle'] = None
@@ -653,12 +660,13 @@ def meta_dict(config, target, src_ids, snap_datasets, proc_time, start, stop, co
         meta['source'][uid]['perfIntegratedSideLobeRatio'] = islr
         meta['source'][uid]['perfPeakSideLobeRatio'] = pslr
         meta['source'][uid]['polCalMatrices'] = None
-        meta['source'][uid]['processingCenter'] = f"{src_xml[uid]['manifest'].find('.//safe:facility', nsmap).attrib['organisation']} " \
-                                                  f"{src_xml[uid]['manifest'].find('.//safe:facility', nsmap).attrib['name']}".replace(' -', '')
-        meta['source'][uid]['processingDate'] = src_xml[uid]['manifest'].find('.//safe:processing', nsmap).attrib['stop']
-        meta['source'][uid]['processingLevel'] = src_xml[uid]['manifest'].find('.//safe:processing', nsmap).attrib['name']
-        meta['source'][uid]['processorName'] = src_xml[uid]['manifest'].find('.//safe:software', nsmap).attrib['name']
-        meta['source'][uid]['processorVersion'] = src_xml[uid]['manifest'].find('.//safe:software', nsmap).attrib['version']
+        fac_org = read_manifest('.//safe:facility', attrib='organisation')
+        fac_name = read_manifest('.//safe:facility', attrib='name')
+        meta['source'][uid]['processingCenter'] = f"{fac_org} {fac_name}".replace(' -', '')
+        meta['source'][uid]['processingDate'] = read_manifest('.//safe:processing', attrib='stop')
+        meta['source'][uid]['processingLevel'] = read_manifest('.//safe:processing', attrib='name')
+        meta['source'][uid]['processorName'] = read_manifest('.//safe:software', attrib='name')
+        meta['source'][uid]['processorVersion'] = read_manifest('.//safe:software', attrib='version')
         meta['source'][uid]['processingMode'] = 'NOMINAL'
         meta['source'][uid]['productType'] = src_sid[uid].meta['product']
         meta['source'][uid]['rangeLookBandwidth'] = rg_look_bandwidth
@@ -670,10 +678,8 @@ def meta_dict(config, target, src_ids, snap_datasets, proc_time, start, stop, co
         meta['source'][uid]['sensorCalibration'] = url
         meta['source'][uid]['status'] = 'ARCHIVED'
         meta['source'][uid]['swaths'] = swaths
-        meta['source'][uid]['timeCompletionFromAscendingNode'] = str(float(src_xml[uid]['manifest']
-                                                                           .find('.//s1:stopTimeANX', nsmap).text))
-        meta['source'][uid]['timeStartFromAscendingNode'] = str(float(src_xml[uid]['manifest']
-                                                                      .find('.//s1:startTimeANX', nsmap).text))
+        meta['source'][uid]['timeCompletionFromAscendingNode'] = str(float(read_manifest('.//s1:stopTimeANX')))
+        meta['source'][uid]['timeStartFromAscendingNode'] = str(float(read_manifest('.//s1:startTimeANX')))
         meta['source'][uid]['timeStart'] = datetime.strptime(src_sid[uid].start, '%Y%m%dT%H%M%S')
         meta['source'][uid]['timeStop'] = datetime.strptime(src_sid[uid].stop, '%Y%m%dT%H%M%S')
     

--- a/S1_NRB/metadata/extract.py
+++ b/S1_NRB/metadata/extract.py
@@ -11,7 +11,7 @@ from spatialist.vector import wkt2vector, bbox
 from spatialist.raster import rasterize
 from osgeo import gdal
 import S1_NRB
-from S1_NRB.metadata.mapping import NRB_PATTERN, ITEM_MAP, RES_MAP, ORB_MAP, DEM_MAP
+from S1_NRB.metadata.mapping import NRB_PATTERN, ITEM_MAP, ORB_MAP, DEM_MAP
 
 gdal.UseExceptions()
 
@@ -231,14 +231,15 @@ def find_in_annotation(annotation_dict, pattern, single=False, out_type=None):
         value will be returned instead of a dict. If the results differ, an error is raised. Default is False.
     out_type: str, optional
         Output type to convert the results to. Can be one of the following:
-        str (default)
-        float
-        int
+        
+        - str (default)
+        - float
+        - int
     
     Returns
     -------
     out: dict
-        A dict of the results containing a list for each of the annotation files.
+        A dictionary of the results containing a list for each of the annotation files.
         I.e., {'swath ID': list[str, float or int]}
     """
     if out_type is None:
@@ -418,9 +419,9 @@ def meta_dict(config, target, src_ids, snap_datasets, proc_time, start, stop, co
     config: dict
         Dictionary of the parsed config parameters for the current process.
     target: str
-        A path pointing to the root directory of a product scene.
+        A path pointing to the NRB product scene being created.
     src_ids: list[ID]
-        List of `pyroSAR.driver.ID` objects of all source SLC scenes that overlap with the current MGRS tile.
+        List of `pyroSAR.driver.ID` objects of all source scenes that overlap with the current MGRS tile.
     snap_datasets: list[str]
         List of output files processed with `pyroSAR.snap.util.geocode` that match the source SLC scenes that overlap
         with the current MGRS tile.
@@ -481,8 +482,10 @@ def meta_dict(config, target, src_ids, snap_datasets, proc_time, start, stop, co
     meta['common']['platformShortName'] = 'Sentinel'
     meta['common']['platformFullname'] = '{}-{}'.format(meta['common']['platformShortName'].lower(),
                                                         meta['common']['platformIdentifier'].lower())
-    meta['common']['platformReference'] = {'sentinel-1a': 'http://database.eohandbook.com/database/missionsummary.aspx?missionID=575',
-                                           'sentinel-1b': 'http://database.eohandbook.com/database/missionsummary.aspx?missionID=576'}[meta['common']['platformFullname']]
+    meta['common']['platformReference'] = \
+        {'sentinel-1a': 'http://database.eohandbook.com/database/missionsummary.aspx?missionID=575',
+         'sentinel-1b': 'http://database.eohandbook.com/database/missionsummary.aspx?missionID=576'}[
+            meta['common']['platformFullname']]
     meta['common']['polarisationChannels'] = sid0.polarizations
     meta['common']['polarisationMode'] = prod_meta['pols'][0]
     meta['common']['processingLevel'] = 'L1C'
@@ -495,7 +498,8 @@ def meta_dict(config, target, src_ids, snap_datasets, proc_time, start, stop, co
     
     # Product metadata (sorted alphabetically)
     meta['prod']['access'] = None
-    meta['prod']['ancillaryData_KML'] = 'https://sentinels.copernicus.eu/documents/247904/1955685/S2A_OPER_GIP_TILPAR_MPC__20151209T095117_V20150622T000000_21000101T000000_B00.kml'
+    meta['prod'][
+        'ancillaryData_KML'] = 'https://sentinels.copernicus.eu/documents/247904/1955685/S2A_OPER_GIP_TILPAR_MPC__20151209T095117_V20150622T000000_21000101T000000_B00.kml'
     meta['prod']['acquisitionType'] = 'NOMINAL'
     meta['prod']['azimuthNumberOfLooks'] = prod_meta['ML_nAzLooks']
     meta['prod']['backscatterConvention'] = 'linear power'
@@ -528,7 +532,8 @@ def meta_dict(config, target, src_ids, snap_datasets, proc_time, start, stop, co
     meta['prod']['geoCorrAccuracy_rRMSE'] = None
     meta['prod']['geoCorrAccuracyReference'] = 'https://www.mdpi.com/2072-4292/9/6/607'
     meta['prod']['geoCorrAccuracyType'] = 'slant-range'
-    meta['prod']['geoCorrAlgorithm'] = 'https://sentinel.esa.int/documents/247904/1653442/Guide-to-Sentinel-1-Geocoding.pdf'
+    meta['prod'][
+        'geoCorrAlgorithm'] = 'https://sentinel.esa.int/documents/247904/1653442/Guide-to-Sentinel-1-Geocoding.pdf'
     meta['prod']['geoCorrResamplingMethod'] = 'bilinear'
     meta['prod']['geom_stac_bbox_native'] = stac_bbox_native
     meta['prod']['geom_stac_bbox_4326'] = stac_bbox
@@ -577,24 +582,31 @@ def meta_dict(config, target, src_ids, snap_datasets, proc_time, start, stop, co
         stac_bbox, stac_geometry = convert_coordinates(coords=coords, stac=True)
         
         az_look_bandwidth = find_in_annotation(annotation_dict=src_xml[uid]['annotation'],
-                                               pattern='.//azimuthProcessing/lookBandwidth', out_type='float')
+                                               pattern='.//azimuthProcessing/lookBandwidth',
+                                               out_type='float')
         az_num_looks = find_in_annotation(annotation_dict=src_xml[uid]['annotation'],
-                                          pattern='.//azimuthProcessing/numberOfLooks', single=True)
+                                          pattern='.//azimuthProcessing/numberOfLooks',
+                                          single=True)
         az_px_spacing = find_in_annotation(annotation_dict=src_xml[uid]['annotation'],
                                            pattern='.//azimuthPixelSpacing', out_type='float')
         inc = find_in_annotation(annotation_dict=src_xml[uid]['annotation'],
-                                 pattern='.//geolocationGridPoint/incidenceAngle', out_type='float')
+                                 pattern='.//geolocationGridPoint/incidenceAngle',
+                                 out_type='float')
         inc_vals = list(inc.values())
         lut_applied = find_in_annotation(annotation_dict=src_xml[uid]['annotation'],
                                          pattern='.//applicationLutId', single=True)
         pslr, islr = extract_pslr_islr(annotation_dict=src_xml[uid]['annotation'])
         np_files = [ds for ds in snap_datasets if re.search('_NE[BGS]Z', ds) is not None]
         rg_look_bandwidth = find_in_annotation(annotation_dict=src_xml[uid]['annotation'],
-                                               pattern='.//rangeProcessing/lookBandwidth', out_type='float')
+                                               pattern='.//rangeProcessing/lookBandwidth',
+                                               out_type='float')
         rg_num_looks = find_in_annotation(annotation_dict=src_xml[uid]['annotation'],
-                                          pattern='.//rangeProcessing/numberOfLooks', single=True)
-        rg_px_spacing = find_in_annotation(annotation_dict=src_xml[uid]['annotation'], pattern='.//rangePixelSpacing',
+                                          pattern='.//rangeProcessing/numberOfLooks',
+                                          single=True)
+        rg_px_spacing = find_in_annotation(annotation_dict=src_xml[uid]['annotation'],
+                                           pattern='.//rangePixelSpacing',
                                            out_type='float')
+        res_rg, res_az = src_sid[uid].resolution()
         
         # (sorted alphabetically)
         meta['source'][uid] = {}
@@ -605,10 +617,11 @@ def meta_dict(config, target, src_ids, snap_datasets, proc_time, start, stop, co
         meta['source'][uid]['azimuthNumberOfLooks'] = az_num_looks
         meta['source'][uid]['azimuthPixelSpacing'] = str(sum(list(az_px_spacing.values())) /
                                                          len(list(az_px_spacing.values())))
-        meta['source'][uid]['azimuthResolution'] = RES_MAP[meta['common']['operationalMode']]['azimuthResolution']
+        meta['source'][uid]['azimuthResolution'] = str(res_az)
         meta['source'][uid]['dataGeometry'] = 'slant range'
         meta['source'][uid]['datatakeID'] = src_xml[uid]['manifest'].find('.//s1sarl1:missionDataTakeID', nsmap).text
-        meta['source'][uid]['doi'] = 'https://sentinel.esa.int/documents/247904/1877131/Sentinel-1-Product-Specification'
+        url = 'https://sentinel.esa.int/documents/247904/1877131/Sentinel-1-Product-Specification'
+        meta['source'][uid]['doi'] = url
         meta['source'][uid]['faradayMeanRotationAngle'] = None
         meta['source'][uid]['faradayRotationReference'] = None
         meta['source'][uid]['filename'] = src_sid[uid].file
@@ -652,8 +665,9 @@ def meta_dict(config, target, src_ids, snap_datasets, proc_time, start, stop, co
         meta['source'][uid]['rangeNumberOfLooks'] = rg_num_looks
         meta['source'][uid]['rangePixelSpacing'] = str(sum(list(rg_px_spacing.values())) /
                                                        len(list(rg_px_spacing.values())))
-        meta['source'][uid]['rangeResolution'] = RES_MAP[meta['common']['operationalMode']]['rangeResolution']
-        meta['source'][uid]['sensorCalibration'] = 'https://sentinel.esa.int/web/sentinel/technical-guides/sentinel-1-sar/sar-instrument/calibration'
+        meta['source'][uid]['rangeResolution'] = str(res_rg)
+        url = 'https://sentinel.esa.int/web/sentinel/technical-guides/sentinel-1-sar/sar-instrument/calibration'
+        meta['source'][uid]['sensorCalibration'] = url
         meta['source'][uid]['status'] = 'ARCHIVED'
         meta['source'][uid]['swaths'] = swaths
         meta['source'][uid]['timeCompletionFromAscendingNode'] = str(float(src_xml[uid]['manifest']

--- a/S1_NRB/metadata/extract.py
+++ b/S1_NRB/metadata/extract.py
@@ -11,7 +11,7 @@ from spatialist.vector import wkt2vector, bbox
 from spatialist.raster import rasterize
 from osgeo import gdal
 import S1_NRB
-from S1_NRB.metadata.mapping import NRB_PATTERN, ITEM_MAP, ORB_MAP, DEM_MAP
+from S1_NRB.metadata.mapping import NRB_PATTERN, ITEM_MAP, RES_MAP, ORB_MAP, DEM_MAP
 
 gdal.UseExceptions()
 
@@ -585,7 +585,8 @@ def meta_dict(target, src_ids, snap_datasets, dem_type, proc_time, start, stop, 
                                           pattern='.//azimuthProcessing/numberOfLooks',
                                           single=True)
         az_px_spacing = find_in_annotation(annotation_dict=src_xml[uid]['annotation'],
-                                           pattern='.//azimuthPixelSpacing', out_type='float')
+                                           pattern='.//azimuthPixelSpacing',
+                                           out_type='float')
         inc = find_in_annotation(annotation_dict=src_xml[uid]['annotation'],
                                  pattern='.//geolocationGridPoint/incidenceAngle',
                                  out_type='float')
@@ -621,7 +622,7 @@ def meta_dict(target, src_ids, snap_datasets, dem_type, proc_time, start, stop, 
         meta['source'][uid]['azimuthNumberOfLooks'] = az_num_looks
         meta['source'][uid]['azimuthPixelSpacing'] = str(sum(list(az_px_spacing.values())) /
                                                          len(list(az_px_spacing.values())))
-        meta['source'][uid]['azimuthResolution'] = str(res_az)
+        meta['source'][uid]['azimuthResolution'] = RES_MAP[meta['common']['operationalMode']]['azimuthResolution']
         meta['source'][uid]['dataGeometry'] = 'slant range'
         meta['source'][uid]['datatakeID'] = read_manifest('.//s1sarl1:missionDataTakeID')
         url = 'https://sentinel.esa.int/documents/247904/1877131/Sentinel-1-Product-Specification'
@@ -670,7 +671,7 @@ def meta_dict(target, src_ids, snap_datasets, dem_type, proc_time, start, stop, 
         meta['source'][uid]['rangeNumberOfLooks'] = rg_num_looks
         meta['source'][uid]['rangePixelSpacing'] = str(sum(list(rg_px_spacing.values())) /
                                                        len(list(rg_px_spacing.values())))
-        meta['source'][uid]['rangeResolution'] = str(res_rg)
+        meta['source'][uid]['rangeResolution'] = RES_MAP[meta['common']['operationalMode']]['rangeResolution']
         url = 'https://sentinel.esa.int/web/sentinel/technical-guides/sentinel-1-sar/sar-instrument/calibration'
         meta['source'][uid]['sensorCalibration'] = url
         meta['source'][uid]['status'] = 'ARCHIVED'

--- a/S1_NRB/metadata/extract.py
+++ b/S1_NRB/metadata/extract.py
@@ -62,7 +62,7 @@ def get_prod_meta(product_id, tif, src_ids, snap_outdir):
             arr_srcvec = ras_srcvec.array()
             out['nodata_borderpx'] = np.count_nonzero(np.isnan(arr_srcvec))
     
-    pat = 'S1[AB]__(IW|EW|SM)___(A|D)_[0-9]{8}T[0-9]{6}.+ML.+xml$'
+    pat = 'S1[AB]__(IW|EW|S[1-6])___(A|D)_[0-9]{8}T[0-9]{6}.+ML.+xml$'
     wf_path = finder(snap_outdir, [pat], regex=True)
     if len(wf_path) > 0:
         wf = parse_recipe(wf_path[0])
@@ -644,7 +644,14 @@ def meta_dict(target, src_ids, snap_datasets, dem_type, proc_time, start, stop, 
         meta['source'][uid]['azimuthLookBandwidth'] = az_look_bandwidth
         meta['source'][uid]['azimuthNumberOfLooks'] = az_num_looks
         meta['source'][uid]['azimuthPixelSpacing'] = az_px_spacing
-        meta['source'][uid]['azimuthResolution'] = RES_MAP[meta['common']['operationalMode']]['azimuthResolution']
+        op_mode = meta['common']['operationalMode']
+        if re.search('S[1-6]', op_mode):
+            res_az = {op_mode: RES_MAP['SM']['azimuthResolution'][op_mode]}
+            res_rg = {op_mode: RES_MAP['SM']['rangeResolution'][op_mode]}
+        else:
+            res_az = RES_MAP[op_mode]['azimuthResolution']
+            res_rg = RES_MAP[op_mode]['rangeResolution']
+        meta['source'][uid]['azimuthResolution'] = res_az
         if src_sid[uid].meta['product'] == 'GRD':
             meta['source'][uid]['dataGeometry'] = 'ground range'
         else:
@@ -695,7 +702,8 @@ def meta_dict(target, src_ids, snap_datasets, dem_type, proc_time, start, stop, 
         meta['source'][uid]['rangeLookBandwidth'] = rg_look_bandwidth
         meta['source'][uid]['rangeNumberOfLooks'] = rg_num_looks
         meta['source'][uid]['rangePixelSpacing'] = rg_px_spacing
-        meta['source'][uid]['rangeResolution'] = RES_MAP[meta['common']['operationalMode']]['rangeResolution']
+        meta['source'][uid]['azimuthResolution'] = res_az
+        meta['source'][uid]['rangeResolution'] = res_rg
         url = 'https://sentinel.esa.int/web/sentinel/technical-guides/sentinel-1-sar/sar-instrument/calibration'
         meta['source'][uid]['sensorCalibration'] = url
         meta['source'][uid]['status'] = 'ARCHIVED'

--- a/S1_NRB/metadata/extract.py
+++ b/S1_NRB/metadata/extract.py
@@ -137,7 +137,7 @@ def etree_from_sid(sid):
     annotation_files = list(filter(re.compile(pols[0]).search, files))
     
     a_files_base = [os.path.basename(a) for a in annotation_files]
-    swaths = [re.search('-iw[1-3]|-ew[1-5]|-s[1-6]', a).group().replace('-', '') for a in a_files_base]
+    swaths = [re.search('-(iw[1-3]*|ew[1-5]*|s[1-6])', a).group(1) for a in a_files_base]
     
     annotation_dict = {}
     for s, a in zip(swaths, annotation_files):

--- a/S1_NRB/metadata/extract.py
+++ b/S1_NRB/metadata/extract.py
@@ -466,9 +466,11 @@ def meta_dict(target, src_ids, snap_datasets, dem_type, proc_time, start, stop, 
         src_xml[uid] = etree_from_sid(sid=sid)
     sid0 = src_sid[list(src_sid.keys())[0]]  # first key/first file; used to extract some common metadata
     
+    ref_tif = finder(target, ['[hv]{2}-g-lin.tif$'], regex=True)[0]
+    np_tifs = finder(target, ['-np-[hv]{2}.tif$'], regex=True)
+    
     product_id = os.path.basename(target)
-    tif = finder(target, ['[hv]{2}-g-lin.tif$'], regex=True)[0]
-    prod_meta = get_prod_meta(product_id=product_id, tif=tif, src_ids=src_ids,
+    prod_meta = get_prod_meta(product_id=product_id, tif=ref_tif, src_ids=src_ids,
                               snap_outdir=os.path.dirname(snap_datasets[0]))
     
     xml_center, xml_envelop = convert_coordinates(coords=prod_meta['extent_4326'])
@@ -560,8 +562,8 @@ def meta_dict(target, src_ids, snap_datasets, dem_type, proc_time, start, stop, 
     meta['prod']['griddingConvention'] = 'Military Grid Reference System (MGRS)'
     meta['prod']['licence'] = None
     meta['prod']['mgrsID'] = prod_meta['mgrsID']
-    meta['prod']['NRApplied'] = True
-    meta['prod']['NRAlgorithm'] = 'https://doi.org/10.1109/tgrs.2018.2889381'
+    meta['prod']['NRApplied'] = True if len(np_tifs) > 0 else False
+    meta['prod']['NRAlgorithm'] = 'https://doi.org/10.1109/tgrs.2018.2889381' if meta['prod']['NRApplied'] else None
     meta['prod']['numberOfAcquisitions'] = str(len(src_sid))
     meta['prod']['numBorderPixels'] = prod_meta['nodata_borderpx']
     meta['prod']['numLines'] = str(prod_meta['rows'])
@@ -679,7 +681,7 @@ def meta_dict(target, src_ids, snap_datasets, dem_type, proc_time, start, stop, 
                 meta['source'][uid]['orbitDataSource'] = ORB_MAP[orb]
         meta['source'][uid]['orbitDataAccess'] = 'https://scihub.copernicus.eu/gnss'
         if len(np_files) > 0:
-            meta['source'][uid]['perfEstimates'] = calc_performance_estimates(files=np_files, ref_tif=tif)
+            meta['source'][uid]['perfEstimates'] = calc_performance_estimates(files=np_files, ref_tif=ref_tif)
             meta['source'][uid]['perfNoiseEquivalentIntensityType'] = 'sigma0'
         else:
             stats = {stat: None for stat in ['minimum', 'mean', 'maximum']}

--- a/S1_NRB/metadata/extract.py
+++ b/S1_NRB/metadata/extract.py
@@ -216,7 +216,7 @@ def convert_coordinates(coords, stac=False):
         return center, envelop
 
 
-def find_in_annotation(annotation_dict, pattern, single=False, out_type=None):
+def find_in_annotation(annotation_dict, pattern, single=False, out_type='str'):
     """
     Search for a pattern in all XML annotation files provided and return a dictionary of results.
     
@@ -229,7 +229,7 @@ def find_in_annotation(annotation_dict, pattern, single=False, out_type=None):
     single: bool, optional
         If True, the results found in each annotation file are expected to be the same and therefore only a single
         value will be returned instead of a dict. If the results differ, an error is raised. Default is False.
-    out_type: str, optional
+    out_type: str
         Output type to convert the results to. Can be one of the following:
         
         - str (default)
@@ -242,9 +242,6 @@ def find_in_annotation(annotation_dict, pattern, single=False, out_type=None):
         A dictionary of the results containing a list for each of the annotation files.
         I.e., {'swath ID': list[str, float or int]}
     """
-    if out_type is None:
-        out_type = 'str'
-    
     out = {}
     for s, a in annotation_dict.items():
         out[s] = [x.text for x in a.findall(pattern)]

--- a/S1_NRB/metadata/mapping.py
+++ b/S1_NRB/metadata/mapping.py
@@ -42,38 +42,6 @@ ITEM_MAP = {'VV_gamma0': {'suffix': 'vv-g-lin',
             'HV_NESZ': {'suffix': 'np-hv',
                         'z_error': 2e-5}}
 
-# Source data resolution
-# https://sentinels.copernicus.eu/web/sentinel/technical-guides/sentinel-1-sar/products-algorithms/level-1-algorithms/single-look-complex
-RES_MAP = {'IW': {'azimuthResolution': {'IW1': '22.5',
-                                        'IW2': '22.7',
-                                        'IW3': '22.6'},
-                  'rangeResolution': {'IW1': '2.7',
-                                      'IW2': '3.1',
-                                      'IW3': '3.5'}},
-           'EW': {'azimuthResolution': {'EW1': '43.7',
-                                        'EW2': '44.3',
-                                        'EW3': '45.2',
-                                        'EW4': '45.6',
-                                        'EW5': '44.0'},
-                  'rangeResolution': {'EW1': '7.9',
-                                      'EW2': '9.9',
-                                      'EW3': '11.6',
-                                      'EW4': '13.3',
-                                      'EW5': '14.4'}},
-           'SM': {'azimuthResolution': {'S1': '4.9',
-                                        'S2': '4.9',
-                                        'S3': '4.9',
-                                        'S4': '4.9',
-                                        'S5': '3.9',
-                                        'S6': '4.9'},
-                  'rangeResolution': {'S1': '1.7',
-                                      'S2': '2.0',
-                                      'S3': '2.5',
-                                      'S4': '3.3',
-                                      'S5': '3.3',
-                                      'S6': '3.6'}}
-           }
-
 ORB_MAP = {'PREORB': 'predicted',
            'RESORB': 'restituted',
            'POEORB': 'precise'}

--- a/S1_NRB/metadata/mapping.py
+++ b/S1_NRB/metadata/mapping.py
@@ -42,6 +42,38 @@ ITEM_MAP = {'VV_gamma0': {'suffix': 'vv-g-lin',
             'HV_NESZ': {'suffix': 'np-hv',
                         'z_error': 2e-5}}
 
+# Source data resolution
+# https://sentinels.copernicus.eu/web/sentinel/technical-guides/sentinel-1-sar/products-algorithms/level-1-algorithms/single-look-complex
+RES_MAP = {'IW': {'azimuthResolution': {'IW1': 22.5,
+                                        'IW2': 22.7,
+                                        'IW3': 22.6},
+                  'rangeResolution': {'IW1': 2.7,
+                                      'IW2': 3.1,
+                                      'IW3': 3.5}},
+           'EW': {'azimuthResolution': {'EW1': 43.7,
+                                        'EW2': 44.3,
+                                        'EW3': 45.2,
+                                        'EW4': 45.6,
+                                        'EW5': 44.0},
+                  'rangeResolution': {'EW1': 7.9,
+                                      'EW2': 9.9,
+                                      'EW3': 11.6,
+                                      'EW4': 13.3,
+                                      'EW5': 14.4}},
+           'SM': {'azimuthResolution': {'S1': 4.9,
+                                        'S2': 4.9,
+                                        'S3': 4.9,
+                                        'S4': 4.9,
+                                        'S5': 3.9,
+                                        'S6': 4.9},
+                  'rangeResolution': {'S1': 1.7,
+                                      'S2': 2.0,
+                                      'S3': 2.5,
+                                      'S4': 3.3,
+                                      'S5': 3.3,
+                                      'S6': 3.6}}
+           }
+
 ORB_MAP = {'PREORB': 'predicted',
            'RESORB': 'restituted',
            'POEORB': 'precise'}

--- a/S1_NRB/metadata/mapping.py
+++ b/S1_NRB/metadata/mapping.py
@@ -1,5 +1,5 @@
 NRB_PATTERN = r'^(?P<sensor>S1[AB])_' \
-              r'(?P<mode>IW|EW|SM)_' \
+              r'(?P<mode>IW|EW|S[1-6])_' \
               r'(?P<product>NRB)_' \
               r'(?P<resolution>_)' \
               r'(?P<processingLevel>1)' \

--- a/S1_NRB/metadata/stacparser.py
+++ b/S1_NRB/metadata/stacparser.py
@@ -12,7 +12,7 @@ from S1_NRB.metadata.mapping import SAMPLE_MAP
 from S1_NRB.metadata.extract import get_header_size
 
 
-def product_json(meta, target, tifs):
+def product_json(meta, target, tifs, exist_ok=False):
     """
     Function to generate product-level metadata for an NRB target product in STAC compliant JSON format.
     
@@ -24,6 +24,8 @@ def product_json(meta, target, tifs):
         A path pointing to the root directory of a product scene.
     tifs: list[str]
         List of paths to all GeoTIFF files of the currently processed NRB product.
+    exist_ok: bool
+        do not create files if they already exist?
     
     Returns
     -------
@@ -31,11 +33,13 @@ def product_json(meta, target, tifs):
     """
     scene_id = os.path.basename(target)
     outname = os.path.join(target, '{}.json'.format(scene_id))
+    if os.path.isfile(outname) and exist_ok:
+        return
     print(outname)
     
     start = meta['prod']['timeStart']
     stop = meta['prod']['timeStop']
-    date = start + (stop - start)/2
+    date = start + (stop - start) / 2
     
     item = pystac.Item(id=scene_id,
                        geometry=meta['prod']['geom_stac_geometry_4326'],
@@ -208,7 +212,7 @@ def product_json(meta, target, tifs):
                 asset_key = 'noise-power-{}'.format(pol)
             else:
                 asset_key = SAMPLE_MAP[key]['role']
-
+            
             if SAMPLE_MAP[key]['unit'] is None:
                 SAMPLE_MAP[key]['unit'] = 'unitless'
             
@@ -233,9 +237,10 @@ def product_json(meta, target, tifs):
                         raise RuntimeError('{} contains an unexpected number of bands!'.format(tif))
                 else:  # key == '-id.tif'
                     src_list = list(meta['source'].keys())
-                    src_target = [os.path.basename(meta['source'][src]['filename']).replace('.SAFE', '').replace('.zip', '')
-                                  for src in src_list]
-                    vals = {'values': [{'value': [i+1], 'summary': s} for i, s in enumerate(src_target)]}
+                    src_target = [
+                        os.path.basename(meta['source'][src]['filename']).replace('.SAFE', '').replace('.zip', '')
+                        for src in src_list]
+                    vals = {'values': [{'value': [i + 1], 'summary': s} for i, s in enumerate(src_target)]}
                     band_dict = deepcopy(ras_bands_base)
                     band_dict.update(vals)
                     raster_bands = [band_dict]
@@ -269,7 +274,7 @@ def product_json(meta, target, tifs):
     item.save_object(dest_href=outname)
 
 
-def source_json(meta, target):
+def source_json(meta, target, exist_ok=False):
     """
     Function to generate source-level metadata for an NRB target product in STAC compliant JSON format.
     
@@ -279,6 +284,8 @@ def source_json(meta, target):
         Metadata dictionary generated with metadata.extract.meta_dict
     target: str
         A path pointing to the root directory of a product scene.
+    exist_ok: bool
+        do not create files if they already exist?
     
     Returns
     -------
@@ -290,11 +297,13 @@ def source_json(meta, target):
     for uid in list(meta['source'].keys()):
         scene = os.path.basename(meta['source'][uid]['filename']).split('.')[0]
         outname = os.path.join(metadir, '{}.json'.format(scene))
+        if os.path.isfile(outname) and exist_ok:
+            continue
         print(outname)
         
         start = meta['source'][uid]['timeStart']
         stop = meta['source'][uid]['timeStop']
-        date = start + (stop - start)/2
+        date = start + (stop - start) / 2
         
         item = pystac.Item(id=scene,
                            geometry=meta['source'][uid]['geom_stac_geometry_4326'],
@@ -343,7 +352,7 @@ def source_json(meta, target):
         
         item.properties['processing:facility'] = meta['source'][uid]['processingCenter']
         item.properties['processing:software'] = {meta['source'][uid]['processorName']:
-                                                  meta['source'][uid]['processorVersion']}
+                                                      meta['source'][uid]['processorVersion']}
         item.properties['processing:level'] = meta['common']['processingLevel']
         
         item.properties['card4l:specification'] = meta['prod']['productName-short']
@@ -351,7 +360,7 @@ def source_json(meta, target):
         item.properties['card4l:beam_id'] = meta['common']['swathIdentifier']
         item.properties['card4l:orbit_data_source'] = meta['source'][uid]['orbitDataSource']
         item.properties['card4l:orbit_mean_altitude'] = float(meta['common']['orbitMeanAltitude'])
-        range_look_bandwidth = {k: v/1e9 for k, v in meta['source'][uid]['rangeLookBandwidth'].items()}  # GHz
+        range_look_bandwidth = {k: v / 1e9 for k, v in meta['source'][uid]['rangeLookBandwidth'].items()}  # GHz
         azimuth_look_bandwidth = {k: v / 1e9 for k, v in meta['source'][uid]['azimuthLookBandwidth'].items()}  # GHz
         item.properties['card4l:source_processing_parameters'] = {'lut_applied': meta['source'][uid]['lutApplied'],
                                                                   'range_look_bandwidth': range_look_bandwidth,
@@ -366,7 +375,8 @@ def source_json(meta, target):
         item.properties['card4l:incidence_angle_near_range'] = meta['source'][uid]['incidenceAngleMin']
         item.properties['card4l:incidence_angle_far_range'] = meta['source'][uid]['incidenceAngleMax']
         item.properties['card4l:noise_equivalent_intensity'] = meta['source'][uid]['perfEstimates']
-        item.properties['card4l:noise_equivalent_intensity_type'] = meta['source'][uid]['perfNoiseEquivalentIntensityType']
+        item.properties['card4l:noise_equivalent_intensity_type'] = meta['source'][uid][
+            'perfNoiseEquivalentIntensityType']
         item.properties['card4l:peak_sidelobe_ratio'] = meta['source'][uid]['perfPeakSideLobeRatio']
         item.properties['card4l:integrated_sidelobe_ratio'] = meta['source'][uid]['perfIntegratedSideLobeRatio']
         item.properties['card4l:mean_faraday_rotation_angle'] = meta['source'][uid]['faradayMeanRotationAngle']
@@ -416,7 +426,7 @@ def source_json(meta, target):
         item.save_object(dest_href=outname)
 
 
-def main(meta, target, tifs):
+def main(meta, target, tifs, exist_ok=False):
     """
     Wrapper for `source_json` and `product_json`.
     
@@ -428,10 +438,12 @@ def main(meta, target, tifs):
         A path pointing to the root directory of a product scene.
     tifs: list[str]
         List of paths to all GeoTIFF files of the currently processed NRB product.
+    exist_ok: bool
+        do not create files if they already exist?
     
     Returns
     -------
     None
     """
-    source_json(meta=meta, target=target)
-    product_json(meta=meta, target=target, tifs=tifs)
+    source_json(meta=meta, target=target, exist_ok=exist_ok)
+    product_json(meta=meta, target=target, tifs=tifs, exist_ok=exist_ok)

--- a/S1_NRB/metadata/stacparser.py
+++ b/S1_NRB/metadata/stacparser.py
@@ -1,5 +1,6 @@
 import os
 import re
+from statistics import mean, median
 from copy import deepcopy
 from datetime import datetime
 import pystac
@@ -332,13 +333,13 @@ def source_json(meta, target, exist_ok=False):
                       frequency_band=FrequencyBand[meta['common']['radarBand'].upper()],
                       polarizations=[Polarization[pol] for pol in meta['common']['polarisationChannels']],
                       product_type=meta['source'][uid]['productType'],
-                      center_frequency=float(meta['common']['radarCenterFreq']/1e9),
-                      resolution_range=float(min(meta['source'][uid]['rangeResolution'].values())),
-                      resolution_azimuth=float(min(meta['source'][uid]['azimuthResolution'].values())),
-                      pixel_spacing_range=float(meta['source'][uid]['rangePixelSpacing']),
-                      pixel_spacing_azimuth=float(meta['source'][uid]['azimuthPixelSpacing']),
-                      looks_range=int(meta['source'][uid]['rangeNumberOfLooks']),
-                      looks_azimuth=int(meta['source'][uid]['azimuthNumberOfLooks']),
+                      center_frequency=float(meta['common']['radarCenterFreq'] / 1e9),
+                      resolution_range=mean(meta['source'][uid]['rangeResolution'].values()),
+                      resolution_azimuth=mean(meta['source'][uid]['azimuthResolution'].values()),
+                      pixel_spacing_range=mean(meta['source'][uid]['rangePixelSpacing'].values()),
+                      pixel_spacing_azimuth=mean(meta['source'][uid]['azimuthPixelSpacing'].values()),
+                      looks_range=median(meta['source'][uid]['rangeNumberOfLooks'].values()),
+                      looks_azimuth=median(meta['source'][uid]['azimuthNumberOfLooks'].values()),
                       looks_equivalent_number=float(enl),
                       observation_direction=ObservationDirection[meta['common']['antennaLookDirection']])
         

--- a/S1_NRB/metadata/xmlparser.py
+++ b/S1_NRB/metadata/xmlparser.py
@@ -208,7 +208,7 @@ def om_feature_of_interest(root, nsmap, scene_id, extent, center):
     pos.text = center
 
 
-def product_xml(meta, target, tifs, nsmap):
+def product_xml(meta, target, tifs, nsmap, exist_ok=False):
     """
     Function to generate product-level metadata for an NRB target product in OGC 10-157r4 compliant XML format.
     
@@ -222,6 +222,8 @@ def product_xml(meta, target, tifs, nsmap):
         List of paths to all GeoTIFF files of the currently processed NRB product.
     nsmap: dict
         Dictionary listing abbreviation (key) and URI (value) of all necessary XML namespaces.
+    exist_ok: bool
+        do not create the file of it already exists?
     
     Returns
     -------
@@ -229,6 +231,8 @@ def product_xml(meta, target, tifs, nsmap):
     """
     scene_id = os.path.basename(target)
     outname = os.path.join(target, '{}.xml'.format(scene_id))
+    if os.path.isfile(outname) and exist_ok:
+        return
     print(outname)
     timeCreated = datetime.strftime(meta['prod']['timeCreated'], '%Y-%m-%dT%H:%M:%S.%f')
     timeStart = datetime.strftime(meta['prod']['timeStart'], '%Y-%m-%dT%H:%M:%S.%f')
@@ -477,7 +481,7 @@ def product_xml(meta, target, tifs, nsmap):
     tree.write(outname, pretty_print=True, xml_declaration=True, encoding='utf-8')
 
 
-def source_xml(meta, target, nsmap):
+def source_xml(meta, target, nsmap, exist_ok=False):
     """
     Function to generate source-level metadata for an NRB target product in OGC 10-157r4 compliant XML format.
     
@@ -489,6 +493,8 @@ def source_xml(meta, target, nsmap):
         A path pointing to the root directory of a product scene.
     nsmap: dict
         Dictionary listing abbreviation (key) and URI (value) of all necessary XML namespaces.
+    exist_ok: bool
+        do not create the file(s) of it already exists?
     
     Returns
     -------
@@ -500,6 +506,8 @@ def source_xml(meta, target, nsmap):
     for uid in list(meta['source'].keys()):
         scene = os.path.basename(meta['source'][uid]['filename']).split('.')[0]
         outname = os.path.join(metadir, '{}.xml'.format(scene))
+        if os.path.isfile(outname) and exist_ok:
+            continue
         print(outname)
         timeStart = datetime.strftime(meta['source'][uid]['timeStart'], '%Y-%m-%dT%H:%M:%S.%f')
         timeStop = datetime.strftime(meta['source'][uid]['timeStop'], '%Y-%m-%dT%H:%M:%S.%f')
@@ -635,7 +643,7 @@ def source_xml(meta, target, nsmap):
         tree.write(outname, pretty_print=True, xml_declaration=True, encoding='utf-8')
 
 
-def main(meta, target, tifs):
+def main(meta, target, tifs, exist_ok=False):
     """
     Wrapper for `source_xml` and `product_xml`.
     
@@ -647,6 +655,8 @@ def main(meta, target, tifs):
         A path pointing to the root directory of a product scene.
     tifs: list[str]
         List of paths to all GeoTIFF files of the currently processed NRB product.
+    exist_ok: bool
+        do not create the file of it already exists?
     
     Returns
     -------
@@ -657,5 +667,5 @@ def main(meta, target, tifs):
     NS_MAP_prod['nrb'] = NS_MAP['nrb']['product']
     NS_MAP_src['nrb'] = NS_MAP['nrb']['source']
     
-    source_xml(meta=meta, target=target, nsmap=NS_MAP_src)
-    product_xml(meta=meta, target=target, tifs=tifs, nsmap=NS_MAP_prod)
+    source_xml(meta=meta, target=target, nsmap=NS_MAP_src, exist_ok=exist_ok)
+    product_xml(meta=meta, target=target, tifs=tifs, nsmap=NS_MAP_prod, exist_ok=exist_ok)

--- a/S1_NRB/metadata/xmlparser.py
+++ b/S1_NRB/metadata/xmlparser.py
@@ -223,7 +223,7 @@ def product_xml(meta, target, tifs, nsmap, exist_ok=False):
     nsmap: dict
         Dictionary listing abbreviation (key) and URI (value) of all necessary XML namespaces.
     exist_ok: bool
-        do not create the file of it already exists?
+        do not create files if they already exist?
     
     Returns
     -------
@@ -494,7 +494,7 @@ def source_xml(meta, target, nsmap, exist_ok=False):
     nsmap: dict
         Dictionary listing abbreviation (key) and URI (value) of all necessary XML namespaces.
     exist_ok: bool
-        do not create the file(s) of it already exists?
+        do not create files if they already exist?
     
     Returns
     -------
@@ -656,7 +656,7 @@ def main(meta, target, tifs, exist_ok=False):
     tifs: list[str]
         List of paths to all GeoTIFF files of the currently processed NRB product.
     exist_ok: bool
-        do not create the file of it already exists?
+        do not create files if they already exist?
     
     Returns
     -------

--- a/S1_NRB/metadata/xmlparser.py
+++ b/S1_NRB/metadata/xmlparser.py
@@ -414,9 +414,9 @@ def product_xml(meta, target, tifs, nsmap, exist_ok=False):
                                    attrib={'codeSpace': 'urn:esa:eop:Sentinel1:class'})
     productType.text = meta['prod']['productName-short']
     azimuthNumberOfLooks = etree.SubElement(earthObservationMetaData, _nsc('nrb:azimuthNumberOfLooks', nsmap))
-    azimuthNumberOfLooks.text = meta['prod']['azimuthNumberOfLooks']
+    azimuthNumberOfLooks.text = str(meta['prod']['azimuthNumberOfLooks'])
     rangeNumberOfLooks = etree.SubElement(earthObservationMetaData, _nsc('nrb:rangeNumberOfLooks', nsmap))
-    rangeNumberOfLooks.text = meta['prod']['rangeNumberOfLooks']
+    rangeNumberOfLooks.text = str(meta['prod']['rangeNumberOfLooks'])
     refDoc = etree.SubElement(earthObservationMetaData, _nsc('nrb:refDoc', nsmap),
                               attrib={'name': meta['prod']['productName'],
                                       'version': meta['prod']['card4l-version'],

--- a/S1_NRB/nrb.py
+++ b/S1_NRB/nrb.py
@@ -1,5 +1,6 @@
 import os
 import re
+import time
 import shutil
 import tempfile
 from datetime import datetime, timezone
@@ -11,6 +12,7 @@ from scipy.interpolate import griddata
 from osgeo import gdal
 from spatialist import Raster, Vector, vectorize, boundary, bbox, intersect, rasterize
 from spatialist.auxil import gdalwarp, gdalbuildvrt
+from spatialist.ancillary import finder
 from pyroSAR import identify, identify_many
 from pyroSAR.ancillary import find_datasets
 import S1_NRB
@@ -59,7 +61,8 @@ def format(config, scenes, datadir, outdir, tile, extent, epsg, wbm=None,
 
     Returns
     -------
-    None
+    str
+        either the time spent executing the function in seconds or 'Already processed - Skip!'
     """
     if compress is None:
         compress = 'LERC_ZSTD'
@@ -71,6 +74,12 @@ def format(config, scenes, datadir, outdir, tile, extent, epsg, wbm=None,
     src_nodata_snap = 0
     dst_nodata = 'nan'
     dst_nodata_mask = 255
+    
+    # determine processing timestamp and generate unique ID
+    start_time = time.time()
+    proc_time = datetime.now(timezone.utc)
+    t = proc_time.isoformat().encode()
+    product_id = generate_unique_id(encoded_str=t)
     
     src_ids, snap_datasets, snap_datamasks = get_datasets(scenes=scenes, datadir=datadir,
                                                           tile=tile, extent=extent, epsg=epsg)
@@ -85,12 +94,21 @@ def format(config, scenes, datadir, outdir, tile, extent, epsg, wbm=None,
             'orbitnumber': src_ids[0].meta['orbitNumbers_abs']['start'],
             'datatake': hex(src_ids[0].meta['frameNumber']).replace('x', '').upper(),
             'tile': tile,
-            'id': 'ABCD'}
+            'id': product_id}
     meta_lower = dict((k, v.lower() if not isinstance(v, int) else v) for k, v in meta.items())
     skeleton_dir = '{mission}_{mode}_NRB__1S{polarization}_{start}_{orbitnumber:06}_{datatake}_{tile}_{id}'
     skeleton_files = '{mission}-{mode}-nrb-{start}-{orbitnumber:06}-{datatake}-{tile}-{suffix}.tif'
     
-    nrb_dir = os.path.join(outdir, skeleton_dir.format(**meta))
+    modify_existing = False
+    nrb_base = skeleton_dir.format(**meta)
+    existing = finder(outdir, [nrb_base.replace(product_id, '*')], foldermode=2)
+    if len(existing) > 0:
+        if not modify_existing:
+            return 'Already processed - Skip!'
+        else:
+            nrb_dir = existing[0]
+    else:
+        nrb_dir = os.path.join(outdir, nrb_base)
     os.makedirs(nrb_dir, exist_ok=True)
     
     # prepare raster write options; https://gdal.org/drivers/raster/cog.html
@@ -167,16 +185,7 @@ def format(config, scenes, datadir, outdir, tile, extent, epsg, wbm=None,
                      options={'format': driver, 'outputBounds': bounds, 'srcNodata': src_nodata_snap,
                               'dstNodata': dst_nodata, 'multithread': multithread,
                               'creationOptions': write_options[key]})
-            nrb_tifs.append(outname)
-    
-    # determine processing timestamp, generate unique ID and rename NRB directory accordingly
-    proc_time = datetime.now(timezone.utc)
-    t = proc_time.isoformat().encode()
-    product_id = generate_unique_id(encoded_str=t)
-    nrb_dir_new = nrb_dir.replace('ABCD', product_id)
-    nrb_tifs = [tif.replace(nrb_dir, nrb_dir_new) for tif in nrb_tifs]
-    os.rename(nrb_dir, nrb_dir_new)
-    nrb_dir = nrb_dir_new
+        nrb_tifs.append(outname)
     
     # reformat `snap_datasets` to a flattened list if necessary
     if type(snap_datasets[0]) == tuple:
@@ -193,23 +202,30 @@ def format(config, scenes, datadir, outdir, tile, extent, epsg, wbm=None,
             raise FileNotFoundError('External water body mask could not be found: {}'.format(wbm))
     
     dm_path = ref_tif.replace(ref_tif_suffix, '-dm.tif')
-    create_data_mask(outname=dm_path, snap_datamasks=snap_datamasks, snap_datasets=snap_datasets,
-                           extent=extent, epsg=epsg, driver=driver, creation_opt=write_options['layoverShadowMask'],
-                           overviews=overviews, overview_resampling=ovr_resampling, wbm=wbm, dst_nodata=dst_nodata_mask)
+    if not os.path.isfile(dm_path):
+        create_data_mask(outname=dm_path, snap_datamasks=snap_datamasks,
+                         snap_datasets=snap_datasets, extent=extent, epsg=epsg,
+                         driver=driver, creation_opt=write_options['layoverShadowMask'],
+                         overviews=overviews, overview_resampling=ovr_resampling,
+                         wbm=wbm, dst_nodata=dst_nodata_mask)
     nrb_tifs.append(dm_path)
     
     # create acquisition ID image raster (-id.tif)
     id_path = ref_tif.replace(ref_tif_suffix, '-id.tif')
-    create_acq_id_image(outname=id_path, ref_tif=ref_tif, snap_datamasks=snap_datamasks, src_ids=src_ids,
-                              extent=extent, epsg=epsg, driver=driver, creation_opt=write_options['acquisitionImage'],
-                              overviews=overviews, dst_nodata=dst_nodata_mask)
+    if not os.path.isfile(id_path):
+        create_acq_id_image(outname=id_path, ref_tif=ref_tif,
+                            snap_datamasks=snap_datamasks, src_ids=src_ids,
+                            extent=extent, epsg=epsg, driver=driver,
+                            creation_opt=write_options['acquisitionImage'],
+                            overviews=overviews, dst_nodata=dst_nodata_mask)
     nrb_tifs.append(id_path)
     
     # create color composite VRT (-cc-g-lin.vrt)
     if meta['polarization'] in ['DH', 'DV'] and len(measure_tifs) == 2:
         cc_path = re.sub('[hv]{2}', 'cc', measure_tifs[0]).replace('.tif', '.vrt')
-        create_rgb_vrt(outname=cc_path, infiles=measure_tifs, overviews=overviews,
-                             overview_resampling=ovr_resampling)
+        if not os.path.isfile(cc_path):
+            create_rgb_vrt(outname=cc_path, infiles=measure_tifs,
+                           overviews=overviews, overview_resampling=ovr_resampling)
     
     # create log-scaled gamma nought VRTs (-[vh|vv|hh|hv]-g-log.vrt)
     for item in measure_tifs:
@@ -217,7 +233,8 @@ def format(config, scenes, datadir, outdir, tile, extent, epsg, wbm=None,
         if not os.path.isfile(gamma0_rtc_log):
             print(gamma0_rtc_log)
             create_vrt(src=item, dst=gamma0_rtc_log, fun='log10', scale=10,
-                             options={'VRTNodata': 'NaN'}, overviews=overviews, overview_resampling=ovr_resampling)
+                       options={'VRTNodata': 'NaN'}, overviews=overviews,
+                       overview_resampling=ovr_resampling)
     
     # create sigma nought RTC VRTs (-[vh|vv|hh|hv]-s-[lin|log].vrt)
     for item in measure_tifs:
@@ -226,13 +243,15 @@ def format(config, scenes, datadir, outdir, tile, extent, epsg, wbm=None,
         
         if not os.path.isfile(sigma0_rtc_lin):
             print(sigma0_rtc_lin)
-            create_vrt(src=[item, ref_tif], dst=sigma0_rtc_lin, fun='mul', relpaths=True,
-                             options={'VRTNodata': 'NaN'}, overviews=overviews, overview_resampling=ovr_resampling)
+            create_vrt(src=[item, ref_tif], dst=sigma0_rtc_lin, fun='mul',
+                       relpaths=True, options={'VRTNodata': 'NaN'}, overviews=overviews,
+                       overview_resampling=ovr_resampling)
         
         if not os.path.isfile(sigma0_rtc_log):
             print(sigma0_rtc_log)
-            create_vrt(src=sigma0_rtc_lin, dst=sigma0_rtc_log, fun='log10', scale=10,
-                             options={'VRTNodata': 'NaN'}, overviews=overviews, overview_resampling=ovr_resampling)
+            create_vrt(src=sigma0_rtc_lin, dst=sigma0_rtc_log, fun='log10',
+                       scale=10, options={'VRTNodata': 'NaN'}, overviews=overviews,
+                       overview_resampling=ovr_resampling)
     
     # copy support files
     schema_dir = os.path.join(S1_NRB.__path__[0], 'validation', 'schemas')
@@ -245,8 +264,9 @@ def format(config, scenes, datadir, outdir, tile, extent, epsg, wbm=None,
     # create metadata files in XML and (STAC) JSON formats
     meta = extract.meta_dict(config=config, target=nrb_dir, src_ids=src_ids, snap_datasets=snap_datasets,
                              proc_time=proc_time, start=nrb_start, stop=nrb_stop, compression=compress)
-    xmlparser.main(meta=meta, target=nrb_dir, tifs=nrb_tifs)
-    stacparser.main(meta=meta, target=nrb_dir, tifs=nrb_tifs)
+    xmlparser.main(meta=meta, target=nrb_dir, tifs=nrb_tifs, exist_ok=True)
+    stacparser.main(meta=meta, target=nrb_dir, tifs=nrb_tifs, exist_ok=True)
+    return str(round((time.time() - start_time), 2))
 
 
 def get_datasets(scenes, datadir, tile, extent, epsg):

--- a/S1_NRB/nrb.py
+++ b/S1_NRB/nrb.py
@@ -576,11 +576,11 @@ def calc_product_start_stop(src_ids, extent, epsg):
         slc_dict[uid]['sid'] = sid
     
     uids = list(slc_dict.keys())
-    swaths = list(slc_dict[uids[0]]['annotation'].keys())
     
     for uid in uids:
         t = find_in_annotation(annotation_dict=slc_dict[uid]['annotation'],
                                pattern='.//geolocationGridPoint/azimuthTime')
+        swaths = t.keys()
         y = find_in_annotation(annotation_dict=slc_dict[uid]['annotation'], pattern='.//geolocationGridPoint/latitude')
         x = find_in_annotation(annotation_dict=slc_dict[uid]['annotation'], pattern='.//geolocationGridPoint/longitude')
         t_flat = np.asarray([datetime.fromisoformat(item).timestamp() for sublist in [t[swath] for swath in swaths]

--- a/S1_NRB/nrb.py
+++ b/S1_NRB/nrb.py
@@ -262,8 +262,9 @@ def format(config, scenes, datadir, outdir, tile, extent, epsg, wbm=None,
         shutil.copy(schema, support_dir)
     
     # create metadata files in XML and (STAC) JSON formats
-    meta = extract.meta_dict(config=config, target=nrb_dir, src_ids=src_ids, snap_datasets=snap_datasets,
-                             proc_time=proc_time, start=nrb_start, stop=nrb_stop, compression=compress)
+    meta = extract.meta_dict(target=nrb_dir, src_ids=src_ids, snap_datasets=snap_datasets,
+                             dem_type=config['dem_type'], proc_time=proc_time, start=nrb_start,
+                             stop=nrb_stop, compression=compress)
     xmlparser.main(meta=meta, target=nrb_dir, tifs=nrb_tifs, exist_ok=True)
     stacparser.main(meta=meta, target=nrb_dir, tifs=nrb_tifs, exist_ok=True)
     return str(round((time.time() - start_time), 2))

--- a/S1_NRB/nrb.py
+++ b/S1_NRB/nrb.py
@@ -262,9 +262,11 @@ def format(config, scenes, datadir, outdir, tile, extent, epsg, wbm=None,
         shutil.copy(schema, support_dir)
     
     # create metadata files in XML and (STAC) JSON formats
+    start = datetime.strptime(nrb_start, '%Y%m%dT%H%M%S')
+    stop = datetime.strptime(nrb_stop, '%Y%m%dT%H%M%S')
     meta = extract.meta_dict(target=nrb_dir, src_ids=src_ids, snap_datasets=snap_datasets,
-                             dem_type=config['dem_type'], proc_time=proc_time, start=nrb_start,
-                             stop=nrb_stop, compression=compress)
+                             dem_type=config['dem_type'], proc_time=proc_time, start=start,
+                             stop=stop, compression=compress)
     xmlparser.main(meta=meta, target=nrb_dir, tifs=nrb_tifs, exist_ok=True)
     stacparser.main(meta=meta, target=nrb_dir, tifs=nrb_tifs, exist_ok=True)
     return str(round((time.time() - start_time), 2))

--- a/S1_NRB/processor.py
+++ b/S1_NRB/processor.py
@@ -184,13 +184,13 @@ def main(config_file, section_name, debug=False):
                       'Scenes {s}/{s_total}: {scenes} '.format(tile=tile, t=t + 1, t_total=len(aoi_tiles),
                                                                scenes=[os.path.basename(s) for s in scenes],
                                                                s=s + 1, s_total=len(selection_grouped)))
-                start_time = time.time()
                 try:
-                    nrb.format(config=config, scenes=scenes, datadir=config['rtc_dir'], outdir=outdir,
-                               tile=tile, extent=geo_dict[tile]['ext'], epsg=epsg, wbm=wbm,
-                               multithread=gdal_prms['multithread'])
-                    log(handler=logger, mode='info', proc_step='NRB', scenes=scenes, epsg=epsg,
-                        msg=round((time.time() - start_time), 2))
+                    msg = nrb.format(config=config, scenes=scenes, datadir=config['rtc_dir'], outdir=outdir,
+                                     tile=tile, extent=geo_dict[tile]['ext'], epsg=epsg, wbm=wbm,
+                                     multithread=gdal_prms['multithread'])
+                    if msg == 'Already processed - Skip!':
+                        print('### ' + msg)
+                    log(handler=logger, mode='info', proc_step='NRB', scenes=scenes, epsg=epsg, msg=msg)
                 except Exception as e:
                     log(handler=logger, mode='exception', proc_step='NRB', scenes=scenes, epsg=epsg, msg=e)
                     continue

--- a/S1_NRB/processor.py
+++ b/S1_NRB/processor.py
@@ -97,6 +97,16 @@ def main(config_file, section_name, debug=False):
                 scene = etad.process(scene=scene, etad_dir=config['etad_dir'],
                                      out_dir=tmp_dir_scene, log=logger)
             ###############################################
+            if scene.product == 'SLC':
+                rlks = {'IW': 5,
+                        'SM': 6,
+                        'EW': 3}[config['acq_mode']]
+                azlks = {'IW': 1,
+                         'SM': 6,
+                         'EW': 1}[config['acq_mode']]
+            else:
+                rlks = azlks = None
+            ###############################################
             list_processed = finder(out_dir_scene_epsg, ['*'])
             exclude = list(np_dict.values())
             print('###### [GEOCODE] Scene {s}/{s_total}: {scene}'.format(s=i + 1, s_total=len(ids),
@@ -107,7 +117,8 @@ def main(config_file, section_name, debug=False):
                     geocode(infile=scene, outdir=out_dir_scene_epsg, t_srs=epsg, tmpdir=tmp_dir_scene_epsg,
                             standardGridOriginX=geo_dict['align']['xmax'],
                             standardGridOriginY=geo_dict['align']['ymin'],
-                            externalDEMFile=fname_dem, externalDEMNoDataValue=ex_dem_nodata, **geocode_prms)
+                            externalDEMFile=fname_dem, externalDEMNoDataValue=ex_dem_nodata,
+                            rlks=rlks, azlks=azlks, **geocode_prms)
                     t = round((time.time() - start_time), 2)
                     log(handler=logger, mode='info', proc_step='GEOCODE', scenes=scene.scene, epsg=epsg, msg=t)
                     if t <= 500:
@@ -135,9 +146,9 @@ def main(config_file, section_name, debug=False):
                                 standardGridOriginY=geo_dict['align']['ymin'],
                                 clean_edges=geocode_prms['clean_edges'],
                                 clean_edges_npixels=geocode_prms['clean_edges_npixels'],
-                                rlks=geocode_prms['rlks'], azlks=geocode_prms['azlks'])
+                                rlks=rlks, azlks=rlks)
                     log(handler=logger, mode='info', proc_step='NOISE_P', scenes=scene.scene, epsg=epsg,
-                         msg=round((time.time() - start_time), 2))
+                        msg=round((time.time() - start_time), 2))
                 except Exception as e:
                     log(handler=logger, mode='exception', proc_step='NOISE_P', scenes=scene.scene, epsg=epsg, msg=e)
                     continue
@@ -170,7 +181,7 @@ def main(config_file, section_name, debug=False):
                                tile=tile, extent=geo_dict[tile]['ext'], epsg=epsg, wbm=wbm,
                                multithread=gdal_prms['multithread'])
                     log(handler=logger, mode='info', proc_step='NRB', scenes=scenes, epsg=epsg,
-                         msg=round((time.time() - start_time), 2))
+                        msg=round((time.time() - start_time), 2))
                 except Exception as e:
                     log(handler=logger, mode='exception', proc_step='NRB', scenes=scenes, epsg=epsg, msg=e)
                     continue

--- a/S1_NRB/processor.py
+++ b/S1_NRB/processor.py
@@ -31,16 +31,17 @@ def main(config_file, section_name, debug=False):
     
     with Archive(dbfile=config['db_file']) as archive:
         archive.insert(scenes)
-        selection = archive.select(product='SLC',
+        selection = archive.select(product=config['product'],
                                    acquisition_mode=config['acq_mode'],
                                    mindate=config['mindate'], maxdate=config['maxdate'])
-    ids = identify_many(selection)
     
     if len(selection) == 0:
         message = "No scenes could be found for acquisition mode '{acq_mode}', " \
                   "mindate '{mindate}' and maxdate '{maxdate}' in directory '{scene_dir}'."
         raise RuntimeError(message.format(acq_mode=config['acq_mode'], mindate=config['mindate'],
                                           maxdate=config['maxdate'], scene_dir=config['scene_dir']))
+    
+    ids = identify_many(selection)
     ####################################################################################################################
     # general setup
     geo_dict = tile_ex.get_tile_dict(config=config, spacing=geocode_prms['spacing'])

--- a/S1_NRB/validation/schemas/product.xsd
+++ b/S1_NRB/validation/schemas/product.xsd
@@ -314,8 +314,8 @@
                             <documentation>Number of azimuth looks, which is the number of groups of signal samples (looks) parallel to the flight path.</documentation>
                         </annotation>
                         <simpleType>
-                            <restriction base="integer">
-                                <minInclusive value="0"/>
+                            <restriction base="float">
+                                <minInclusive value="1"/>
                                 <maxInclusive value="100"/>
                             </restriction>
                         </simpleType>
@@ -325,8 +325,8 @@
                             <documentation>Number of range looks, which is the number of groups of signal samples (looks) perpendicular to the flight path.</documentation>
                         </annotation>
                         <simpleType>
-                            <restriction base="integer">
-                                <minInclusive value="0"/>
+                            <restriction base="float">
+                                <minInclusive value="1"/>
                                 <maxInclusive value="100"/>
                             </restriction>
                         </simpleType>
@@ -604,12 +604,12 @@
                             <documentation>Flag indicating if a speckle filtering algorithm been applied while processing.</documentation>
                         </annotation>
                     </element>
-                    <element name="NRApplied" type="boolean" minOccurs="1" maxOccurs="1">
+                    <element name="NRApplied" type="boolean" minOccurs="0" maxOccurs="1">
                         <annotation>
                             <documentation>Flag indicating if a noise removal (NR) algorithm been applied while processing.</documentation>
                         </annotation>
                     </element>
-                    <element name="NRAlgorithm" minOccurs="1" maxOccurs="1">
+                    <element name="NRAlgorithm" minOccurs="0" maxOccurs="1">
                         <annotation>
                             <documentation>Reference to the noise removal algorithm applied during processing.</documentation>
                         </annotation>

--- a/S1_NRB/validation/schemas/source.xsd
+++ b/S1_NRB/validation/schemas/source.xsd
@@ -205,27 +205,41 @@
                             </simpleContent>
                         </complexType>
                     </element>
-                    <element name="azimuthNumberOfLooks" minOccurs="1" maxOccurs="5">
+                    <element name="azimuthNumberOfLooks" minOccurs="1" maxOccurs="6">
                         <annotation>
                             <documentation>Number of azimuth looks, which is the number of groups of signal samples (looks) parallel to the flight path.</documentation>
                         </annotation>
-                        <simpleType>
-                            <restriction base="integer">
-                                <minInclusive value="0"/>
-                                <maxInclusive value="100"/>
-                            </restriction>
-                        </simpleType>
+                        <complexType>
+                            <simpleContent>
+                                <extension base="gml:MeasureType">
+                                    <attribute name="beam" use="required">
+                                        <simpleType>
+                                            <restriction base="string">
+                                                <pattern value="IW[1-3]|EW[1-5]|S[1-6]"/>
+                                            </restriction>
+                                        </simpleType>
+                                    </attribute>
+                                </extension>
+                            </simpleContent>
+                        </complexType>
                     </element>
-                    <element name="rangeNumberOfLooks" minOccurs="1" maxOccurs="5">
+                    <element name="rangeNumberOfLooks" minOccurs="1" maxOccurs="6">
                         <annotation>
                             <documentation>Number of range looks, which is the number of groups of signal samples (looks) perpendicular to the flight path.</documentation>
                         </annotation>
-                        <simpleType>
-                            <restriction base="integer">
-                                <minInclusive value="0"/>
-                                <maxInclusive value="100"/>
-                            </restriction>
-                        </simpleType>
+                        <complexType>
+                            <simpleContent>
+                                <extension base="gml:MeasureType">
+                                    <attribute name="beam" use="required">
+                                        <simpleType>
+                                            <restriction base="string">
+                                                <pattern value="IW[1-3]|EW[1-5]|S[1-6]"/>
+                                            </restriction>
+                                        </simpleType>
+                                    </attribute>
+                                </extension>
+                            </simpleContent>
+                        </complexType>
                     </element>
                     <element name="dataGeometry" minOccurs="1" maxOccurs="1">
                         <annotation>
@@ -234,6 +248,7 @@
                         <simpleType>
                             <restriction base="string">
                                 <enumeration value="slant range"/>
+                                <enumeration value="ground range"
                                 <whiteSpace value="preserve"/>
                             </restriction>
                         </simpleType>
@@ -446,7 +461,7 @@
     </simpleType>
     <complexType name="PerformanceIndicatorsType">
         <sequence>
-            <element name="noiseEquivalentIntensityType" minOccurs="1" maxOccurs="1">
+            <element name="noiseEquivalentIntensityType" minOccurs="0" maxOccurs="1">
                 <annotation>
                     <documentation>Noise equivalent type the performance indicators are provided in.</documentation>
                 </annotation>
@@ -458,7 +473,7 @@
                     </simpleContent>
                 </complexType>
             </element>
-            <element name="estimates" minOccurs="1" maxOccurs="6">
+            <element name="estimates" minOccurs="0" maxOccurs="6">
                 <annotation>
                     <documentation>Performance indicators on data intensity noise level provided for each polarization.</documentation>
                 </annotation>

--- a/S1_NRB/validation/schemas/source.xsd
+++ b/S1_NRB/validation/schemas/source.xsd
@@ -179,6 +179,7 @@
     </element>
     <simpleType name="productTypeBase">
         <restriction base="string">
+            <enumeration value="GRD"/>
             <enumeration value="SLC"/>
         </restriction>
     </simpleType>
@@ -204,7 +205,7 @@
                             </simpleContent>
                         </complexType>
                     </element>
-                    <element name="azimuthNumberOfLooks" minOccurs="1" maxOccurs="1">
+                    <element name="azimuthNumberOfLooks" minOccurs="1" maxOccurs="5">
                         <annotation>
                             <documentation>Number of azimuth looks, which is the number of groups of signal samples (looks) parallel to the flight path.</documentation>
                         </annotation>
@@ -215,7 +216,7 @@
                             </restriction>
                         </simpleType>
                     </element>
-                    <element name="rangeNumberOfLooks" minOccurs="1" maxOccurs="1">
+                    <element name="rangeNumberOfLooks" minOccurs="1" maxOccurs="5">
                         <annotation>
                             <documentation>Number of range looks, which is the number of groups of signal samples (looks) perpendicular to the flight path.</documentation>
                         </annotation>

--- a/config.ini
+++ b/config.ini
@@ -27,6 +27,9 @@ maxdate = 2021-10-21
 # OPTIONS: IW | EW | SM
 acq_mode = IW
 
+# OPTIONS: GRD | SLC
+product = SLC
+
 # NOTE: [work_dir] and [scene_dir] must be full paths to existing directories
 # NOTE: All parameters ending in '_dir' can either be full paths to existing directories of choice OR directory names
 # that will automatically be created as subdirectories of the directory specified with [work_dir].


### PR DESCRIPTION
This adds capability for creating S1-NRB products from SM acquisition mode and GRD products.  
The following changes have been made:

- general
  * adjust to the new pyroSAR naming scheme for Stripmap products from `SM` to `S1..S6` (**new version yet to be published**)
  * enable processing without noise removal and noise power images (currently necessary for SM, see [STEP-32688](https://forum.step.esa.int/t/stripmap-slc-error-during-thermal-noise-removal/32688))
- `config.ini`
  * new parameter `product` to differentiate SLC and GRD
- source product JSON
  * write mean instead of min for attributes `rangeResolution` and `azimuthResolution`
  * write median of all sub-swath values for attributes `rangeNumberOfLooks` and `azimuthNumberOfLooks` (they were expected to the be the same but might actually differ in GRDs)
- source product XML
  * write attributes `rangeNumberOfLooks` and `azimuthNumberOfLooks` per swath (also for GRDs)
- general product metadata
  * determine number of looks by multiplying the factors applied during processing with those found in the source metadata (to support GRD source products)
  * read multiple swath-specific attributes from the original XML metadata files to support GRD (in SLCs each swath has an own file so the first found value did suffice, in GRDs the info from all sub-swaths is comprised in a single file)
- `nrb.format`
  * do not create a product if it already exists