### PR TITLE
set dem download authentication via env. variables

### DIFF
--- a/S1_NRB/dem.py
+++ b/S1_NRB/dem.py
@@ -32,9 +32,11 @@ def prepare(geometries, dem_type, spacing, dem_dir, wbm_dir,
         The coordinate reference system as an EPSG code.
     username: str or None
         The username for accessing the DEM tiles. If None and authentication is required
-        for the selected DEM type, the user is prompted interactively to provide credentials.
+        for the selected DEM type, the environment variable 'DEM_USER' is read.
+        If this is not set, the user is prompted interactively to provide credentials.
     password: str or None
-        The password for accessing the DEM tiles. If None: same behavior as for username.
+        The password for accessing the DEM tiles.
+        If None: same behavior as for username but with env. variable 'DEM_PASS'.
     """
     if dem_type == 'GETASSE30':
         geoid_convert = False
@@ -49,6 +51,11 @@ def prepare(geometries, dem_type, spacing, dem_dir, wbm_dir,
     dems_auth = wbm_dems
     wbm_dir = os.path.join(wbm_dir, dem_type)
     dem_dir = os.path.join(dem_dir, dem_type)
+    
+    if username is None:
+        username = os.getenv('DEM_USER')
+    if password is None:
+        password = os.getenv('DEM_PASS')
     
     for i, geometry in enumerate(geometries):
         print('###### [    DEM] processing geometry {0} of {1}'.format(i + 1, len(geometries)))

--- a/config.ini
+++ b/config.ini
@@ -49,9 +49,11 @@ db_file = scenes.db
 kml_file = S2A_OPER_GIP_TILPAR_MPC__20151209T095117_V20150622T000000_21000101T000000_B00.kml
 
 # OPTIONS: Copernicus 10m EEA DEM | Copernicus 30m Global DEM II | Copernicus 30m Global DEM | GETASSE30
-# Copernicus 30m Global DEM and GETASSE30 do not include a water body mask.
+# The names are taken from the options of function https://pyrosar.readthedocs.io/en/latest/pyroSAR.html#pyroSAR.auxdata.dem_autoload.
+# 'Copernicus 30m Global DEM' and 'GETASSE30' do not include a water body mask.
 # Copernicus 10m EEA DEM and Copernicus 30m Global DEM II include a water body mask. Retrieval requires registration via:
 # https://spacedata.copernicus.eu/web/cscda/data-access/registration
+# Authentication credentials can be set via environment variables 'DEM_USER' and 'DEM_PASS' or interactively during processor runs.
 dem_type = Copernicus 30m Global DEM
 
 # Temporarily changes GDAL_NUM_THREADS during processing. Will be reset after processing has finished.


### PR DESCRIPTION
This lets a user avoid interactive prompts to provide a username and password for download of DEM tiles by setting environment variables `DEM_USER` and `DEM_PASS`.