### PR TITLE
[metadata] read nodata values directly from files (instead of hard-coding them)

### DIFF
--- a/S1_NRB/metadata/stac.py
+++ b/S1_NRB/metadata/stac.py
@@ -177,6 +177,8 @@ def product_json(meta, target, tifs, exist_ok=False):
                                       media_type=pystac.MediaType.XML,
                                       roles=['metadata', 'card4l']))
     for tif in tifs:
+        with Raster(tif) as ras:
+            nodata = ras.nodata
         relpath = './' + os.path.relpath(tif, target).replace('\\', '/')
         size = os.path.getsize(tif)
         header_size = get_header_size(tif=tif)
@@ -186,7 +188,7 @@ def product_json(meta, target, tifs, exist_ok=False):
             created = datetime.fromtimestamp(os.path.getctime(tif)).isoformat()
             extra_fields = {'created': created,
                             'raster:bands': [{'unit': 'natural',
-                                              'nodata': 'NaN',
+                                              'nodata': nodata,
                                               'data_type': '{}{}'.format(meta['prod']['fileDataType'],
                                                                          meta['prod']['fileBitsPerSample']),
                                               'bits_per_sample': int(meta['prod']['fileBitsPerSample'])}],
@@ -217,7 +219,7 @@ def product_json(meta, target, tifs, exist_ok=False):
             
             if key in ['-dm.tif', '-id.tif']:
                 ras_bands_base = {'unit': SAMPLE_MAP[key]['unit'],
-                                  'nodata': 255,
+                                  'nodata': nodata,
                                   'data_type': 'uint8',
                                   'bits_per_sample': 8}
                 raster_bands = []
@@ -251,7 +253,7 @@ def product_json(meta, target, tifs, exist_ok=False):
             
             else:
                 raster_bands = {'unit': SAMPLE_MAP[key]['unit'],
-                                'nodata': 'NaN',
+                                'nodata': nodata,
                                 'data_type': '{}{}'.format(meta['prod']['fileDataType'],
                                                            meta['prod']['fileBitsPerSample']),
                                 'bits_per_sample': int(meta['prod']['fileBitsPerSample'])}

--- a/S1_NRB/metadata/xml.py
+++ b/S1_NRB/metadata/xml.py
@@ -252,6 +252,9 @@ def product_xml(meta, target, tifs, nsmap, exist_ok=False):
         pattern = '|'.join(z_errors.keys())
         match = re.search(pattern, os.path.basename(tif))
         
+        with Raster(tif) as ras:
+            nodata = ras.nodata
+        
         product = etree.SubElement(earthObservationResult, _nsc('eop:product', nsmap))
         productInformation = etree.SubElement(product, _nsc('s1-nrb:ProductInformation', nsmap))
         fileName = etree.SubElement(productInformation, _nsc('eop:fileName', nsmap))
@@ -272,7 +275,7 @@ def product_xml(meta, target, tifs, nsmap, exist_ok=False):
         bitsPerSample = etree.SubElement(productInformation, _nsc('s1-nrb:bitsPerSample', nsmap))
         bitsPerSample.text = meta['prod']['fileBitsPerSample']
         noDataVal = etree.SubElement(productInformation, _nsc('s1-nrb:noDataValue', nsmap))
-        noDataVal.text = 'NaN'
+        noDataVal.text = str(nodata)
         compressionType = etree.SubElement(productInformation, _nsc('s1-nrb:compressionType', nsmap))
         compressionType.text = meta['prod']['compression_type']
         if match is not None:
@@ -289,7 +292,6 @@ def product_xml(meta, target, tifs, nsmap, exist_ok=False):
             if key in ['-dm.tif', '-id.tif']:
                 dataType.text = 'UINT'
                 bitsPerSample.text = '8'
-                noDataVal.text = '255'
                 
                 if key == '-dm.tif':
                     with Raster(tif) as dm_ras:


### PR DESCRIPTION
This removes an error source in case the nodata values are adjusted in the future. After the change from `NaN` to `-9999` for the float images, the metadata files contained the wrong value.