### PR TITLE
[metadata.stac] add VRT assets

### DIFF
--- a/S1_NRB/metadata/stac.py
+++ b/S1_NRB/metadata/stac.py
@@ -193,7 +193,7 @@ def product_json(meta, target, tifs, exist_ok=False):
                 pol = re.search('[vh]{2}', asset).group()
                 nought = measurement_title_dict[re.search('-[g|s]-', asset).group().replace('-', '')]
                 scaling = measurement_title_dict[re.search('(lin|log)', asset).group()]
-                title = '{} scaled {} backscatter ({})'.format(scaling.capitalize(), nought, pol.upper())
+                title = '{} {} RTC backscatter, {} scaling'.format(pol.upper(), nought, scaling.capitalize())
             
             header_size = get_header_size(tif=asset)
             if asset.endswith('.tif'):

--- a/S1_NRB/metadata/stac.py
+++ b/S1_NRB/metadata/stac.py
@@ -181,6 +181,9 @@ def product_json(meta, target, tifs, exist_ok=False):
     assets = tifs + vrts
     measurement_title_dict = {'g': 'gamma nought', 's': 'sigma nought', 'lin': 'linear', 'log': 'logarithmic'}
     for asset in assets:
+        if asset.endswith('.tif'):
+            with Raster(asset) as ras:
+                nodata = ras.nodata
         relpath = './' + os.path.relpath(asset, target).replace('\\', '/')
         size = os.path.getsize(asset)
         
@@ -197,8 +200,6 @@ def product_json(meta, target, tifs, exist_ok=False):
             
             header_size = get_header_size(tif=asset)
             if asset.endswith('.tif'):
-                with Raster(asset) as ras:
-                    nodata = ras.nodata
                 created = datetime.fromtimestamp(os.path.getctime(asset)).isoformat()
                 extra_fields = {'created': created,
                                 'raster:bands': [{'unit': 'natural',


### PR DESCRIPTION
One aspect that might need to be discussed with this PR is that I changed the asset keys of the main backscatter assets (e.g. from `vh` to `vh-g-lin`). What do you think @johntruckenbrodt ? 
Here is an example of how it currently would look like: 

```json
    "vh-g-lin": {
      "href": "./measurement/s1a-iw-nrb-20200103t170705-030639-0382d5-32tps-vh-g-lin.tif",
      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
      "title": "Linear scaled gamma nought backscatter (VH)",
      "created": "2022-07-15T16:36:26.569095",
      "raster:bands": [
        {
          "unit": "natural",
          "nodata": -9999.0,
          "data_type": "float32",
          "bits_per_sample": 32
        }
      ],
      "file:byte_order": "little-endian",
      "file:size": 201582798,
      "file:header_size": 6830,
      "card4l:border_pixels": 0,
      "roles": [
        "backscatter",
        "data"
      ]
    },
    "vv-g-lin": {
      "href": "./measurement/s1a-iw-nrb-20200103t170705-030639-0382d5-32tps-vv-g-lin.tif",
      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
      "title": "Linear scaled gamma nought backscatter (VV)",
      "created": "2022-07-15T16:36:31.064268",
      "raster:bands": [
        {
          "unit": "natural",
          "nodata": -9999.0,
          "data_type": "float32",
          "bits_per_sample": 32
        }
      ],
      "file:byte_order": "little-endian",
      "file:size": 249519956,
      "file:header_size": 6830,
      "card4l:border_pixels": 0,
      "roles": [
        "backscatter",
        "data"
      ]
    },
    
    '[...] annotation assets',

    "cc-g-lin": {
      "href": "./measurement/s1a-iw-nrb-20200103t170705-030639-0382d5-32tps-cc-g-lin.vrt",
      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
      "title": "RGB color composite (vv-g-lin, vh-g-lin, vv-g-lin/vh-g-lin)",
      "file:byte_order": "little-endian",
      "file:size": 4826,
      "roles": [
        "backscatter",
        "data"
      ]
    },
    "vh-g-log": {
      "href": "./measurement/s1a-iw-nrb-20200103t170705-030639-0382d5-32tps-vh-g-log.vrt",
      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
      "title": "Logarithmic scaled gamma nought backscatter (VH)",
      "file:byte_order": "little-endian",
      "file:size": 1672,
      "roles": [
        "backscatter",
        "data"
      ]
    },
    "vh-s-lin": {
      "href": "./measurement/s1a-iw-nrb-20200103t170705-030639-0382d5-32tps-vh-s-lin.vrt",
      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
      "title": "Linear scaled sigma nought backscatter (VH)",
      "file:byte_order": "little-endian",
      "file:size": 2106,
      "roles": [
        "backscatter",
        "data"
      ]
    },
    "vh-s-log": {
      "href": "./measurement/s1a-iw-nrb-20200103t170705-030639-0382d5-32tps-vh-s-log.vrt",
      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
      "title": "Logarithmic scaled sigma nought backscatter (VH)",
      "file:byte_order": "little-endian",
      "file:size": 1655,
      "roles": [
        "backscatter",
        "data"
      ]
    },
    "vv-g-log": {
      "href": "./measurement/s1a-iw-nrb-20200103t170705-030639-0382d5-32tps-vv-g-log.vrt",
      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
      "title": "Logarithmic scaled gamma nought backscatter (VV)",
      "file:byte_order": "little-endian",
      "file:size": 1672,
      "roles": [
        "backscatter",
        "data"
      ]
    },
    "vv-s-lin": {
      "href": "./measurement/s1a-iw-nrb-20200103t170705-030639-0382d5-32tps-vv-s-lin.vrt",
      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
      "title": "Linear scaled sigma nought backscatter (VV)",
      "file:byte_order": "little-endian",
      "file:size": 2106,
      "roles": [
        "backscatter",
        "data"
      ]
    },
    "vv-s-log": {
      "href": "./measurement/s1a-iw-nrb-20200103t170705-030639-0382d5-32tps-vv-s-log.vrt",
      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
      "title": "Logarithmic scaled sigma nought backscatter (VV)",
      "file:byte_order": "little-endian",
      "file:size": 1655,
      "roles": [
        "backscatter",
        "data"
      ]
    }
```

P.S. I'll not be able to change anything until after I come back from vacation, so you'd need to make adjustments yourself if you want to merge this in the coming days 🙂 🌴 