### PR TITLE
Fix and improve metadata geometry handling

### DIFF
--- a/S1_NRB/metadata/extract.py
+++ b/S1_NRB/metadata/extract.py
@@ -107,8 +107,8 @@ def vec_from_srccoords(coord_list):
             c1 = coord_list[0]
             c2 = coord_list[1]
         else:
-            RuntimeError('Not able to find joined border of source scene footprint coordinates:'
-                         '\n{} \n{}'.format(coord_list[0], coord_list[1]))
+            raise RuntimeError('Not able to find joined border of source scene footprint coordinates:'
+                               '\n{} \n{}'.format(coord_list[0], coord_list[1]))
         
         c1_lat = [c1[0][1], c1[1][1], c1[2][1], c1[3][1]]
         c1_lon = [c1[0][0], c1[1][0], c1[2][0], c1[3][0]]

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -125,10 +125,10 @@ Extraction
 
         calc_geolocation_accuracy
         calc_performance_estimates
-        convert_coordinates
         etree_from_sid
         extract_pslr_islr
         find_in_annotation
+        geometry_from_vec
         get_header_size
         get_prod_meta
         meta_dict


### PR DESCRIPTION
I've noticed wrongly calculated footprints due to this issue: https://github.com/opendatacube/odc-stac/issues/83
This should now be fixed as well as another minor bug that I found (error not raised properly). 

The extraction and formatting of geometry information for STAC and XML metadata was completely refactored and the function `convert_coordinates` replaced by `geometry_from_vec`.
