### PR TITLE
SNAP 9 compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,12 @@ RUN apt-get install -y git python3-pip wget libpq-dev
 
 
 WORKDIR /tmp/
-RUN wget https://download.esa.int/step/snap/8.0/installers/esa-snap_sentinel_unix_8_0.sh
+RUN wget https://download.esa.int/step/snap/9.0/installers/esa-snap_sentinel_unix_9_0_0.sh
 COPY docker/esa-snap.varfile /tmp/esa-snap.varfile
-RUN chmod +x esa-snap_sentinel_unix_8_0.sh
+RUN chmod +x esa-snap_sentinel_unix_9_0_0.sh
 
 ## install and update snap
-RUN /tmp/esa-snap_sentinel_unix_8_0.sh -q /tmp/varfile esa-snap.varfile
+RUN /tmp/esa-snap_sentinel_unix_9_0_0.sh -q /tmp/varfile esa-snap.varfile
 RUN apt install -y fonts-dejavu fontconfig
 COPY docker/update_snap.sh /tmp/update_snap.sh
 RUN chmod +x update_snap.sh
@@ -38,8 +38,3 @@ RUN source ~/.bashrc \
 COPY docker/entrypoint.sh entrypoint.sh
 RUN chmod +x entrypoint.sh
 ENTRYPOINT ["/app/entrypoint.sh"]
-
-
-
-
-

--- a/S1_NRB/dem.py
+++ b/S1_NRB/dem.py
@@ -126,7 +126,8 @@ def prepare(geometries, dem_type, spacing, dem_dir, wbm_dir,
                     dem_create(src=fname_wbm_tmp, dst=filename,
                                t_srs=epsg_tile, tr=(tr, tr),
                                resampling_method='mode', pbar=True,
-                               outputBounds=bounds, threads=threads)
+                               outputBounds=bounds, threads=threads,
+                               nodata='None')
         print('=' * 40)
 
 

--- a/S1_NRB/processor.py
+++ b/S1_NRB/processor.py
@@ -1,5 +1,4 @@
 import os
-import re
 import time
 from osgeo import gdal
 from spatialist import Vector
@@ -139,12 +138,6 @@ def main(config_file, section_name='PROCESSING', debug=False):
                          'EW': 1}[config['acq_mode']]
             else:
                 rlks = azlks = None
-            
-            # SLC SM noise removal is currently not possible with SNAP
-            # see https://forum.step.esa.int/t/stripmap-slc-error-during-thermal-noise-removal/32688
-            remove_noise = True
-            if scene.product == 'SLC' and re.search('S[1-6]', scene.acquisition_mode):
-                remove_noise = False
             ###############################################
             list_processed = finder(out_dir_scene_epsg, ['*'])
             exclude = list(np_dict.values())
@@ -157,7 +150,7 @@ def main(config_file, section_name='PROCESSING', debug=False):
                             standardGridOriginX=geo_dict['align']['xmax'],
                             standardGridOriginY=geo_dict['align']['ymin'],
                             externalDEMFile=fname_dem, externalDEMNoDataValue=ex_dem_nodata,
-                            rlks=rlks, azlks=azlks, **geocode_prms, removeS1ThermalNoise=remove_noise)
+                            rlks=rlks, azlks=azlks, **geocode_prms)
                     t = round((time.time() - start_time), 2)
                     log(handler=logger, mode='info', proc_step='GEOCODE', scenes=scene.scene, epsg=epsg, msg=t)
                     if t <= 500:
@@ -171,8 +164,6 @@ def main(config_file, section_name='PROCESSING', debug=False):
                 print('### ' + msg)
                 log(handler=logger, mode='info', proc_step='GEOCODE', scenes=scene.scene, epsg=epsg, msg=msg)
             ###############################################
-            if not remove_noise:
-                continue
             print('###### [NOISE_P] Scene {s}/{s_total}: {scene}'.format(s=i + 1, s_total=len(ids),
                                                                          scene=scene.scene))
             if len([item for item in list_processed if np_dict[np_refarea] in item]) == 0:

--- a/S1_NRB/processor.py
+++ b/S1_NRB/processor.py
@@ -88,6 +88,7 @@ def main(config_file, section_name='PROCESSING', debug=False):
     
     ####################################################################################################################
     # DEM download and MGRS-tiling
+    ex_dem_nodata = None
     if snap_flag:
         geometries = [scene.bbox() for scene in ids]
         dem.prepare(geometries=geometries, threads=gdal_prms['threads'],
@@ -98,8 +99,6 @@ def main(config_file, section_name='PROCESSING', debug=False):
         
         if config['dem_type'] == 'Copernicus 30m Global DEM':
             ex_dem_nodata = -99
-        else:
-            ex_dem_nodata = None
     
     dem_short = {'Copernicus 10m EEA DEM': 'EEA10', 'Copernicus 30m Global DEM II': 'GLO30II',
                  'Copernicus 30m Global DEM': 'GLO30', 'GETASSE30': 'GETASSE30'}

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -11,7 +11,7 @@ dependencies:
   - pip
   - pystac
   - scipy
-  - pyroSAR>=0.17.3
+  - pyroSAR>=0.18.0
   - s1etad>=0.5.3
   - s1etad_tools>=0.8.1
   - sphinx

--- a/environment.yaml
+++ b/environment.yaml
@@ -11,6 +11,6 @@ dependencies:
   - pip
   - pystac
   - scipy
-  - pyroSAR>=0.17.3
+  - pyroSAR>=0.18.0
   - s1etad>=0.5.3
   - s1etad_tools>=0.8.1

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
                       'click',
                       'lxml',
                       'pystac',
-                      'pyroSAR>=0.17.3',
+                      'pyroSAR>=0.18.0',
                       'scipy',
                       's1etad>=0.5.3',
                       's1etad_tools>=0.8.1'],


### PR DESCRIPTION
This bumps up the pyroSAR requirement to >=0.18.0, which is compatible with SNAP 9. This latest SNAP version fixes a bug in stripmap noise power processing, which has now been enabled.