### PR TITLE
sigma0 processing and annotation layer configuration

### DIFF
--- a/S1_NRB/metadata/extract.py
+++ b/S1_NRB/metadata/extract.py
@@ -492,7 +492,11 @@ def meta_dict(config, target, src_ids, rtc_dir, proc_time, start, stop, compress
     
     ref_tif = finder(target, ['[hv]{2}-[gs]-lin.tif$'], regex=True)[0]
     np_tifs = finder(target, ['-np-[hv]{2}.tif$'], regex=True)
-    ei_tif = finder(target, ['-ei.tif$'], regex=True)[0]
+    ei_tifs = finder(target, ['-ei.tif$'], regex=True)
+    if len(ei_tifs) > 0:
+        ei_tif = ei_tifs[0]
+    else:
+        ei_tif = None
     
     product_id = os.path.basename(target)
     prod_meta = get_prod_meta(product_id=product_id, tif=ref_tif,
@@ -508,8 +512,11 @@ def meta_dict(config, target, src_ids, rtc_dir, proc_time, start, stop, compress
     tups = [(key, ITEM_MAP[key]['z_error']) for key in ITEM_MAP.keys()]
     z_err_dict = dict(tups)
     
-    geocorr_acc = calc_geolocation_accuracy(swath_identifier=swath_id, ei_tif=ei_tif,
-                                            dem_type=dem_type, etad=config['etad'])
+    if ei_tif is not None:
+        geocorr_acc = calc_geolocation_accuracy(swath_identifier=swath_id, ei_tif=ei_tif,
+                                                dem_type=dem_type, etad=config['etad'])
+    else:
+        geocorr_acc = None
     
     # Common metadata (sorted alphabetically)
     meta['common']['antennaLookDirection'] = 'RIGHT'

--- a/S1_NRB/metadata/extract.py
+++ b/S1_NRB/metadata/extract.py
@@ -489,7 +489,7 @@ def meta_dict(config, target, src_ids, rtc_dir, proc_time, start, stop, compress
     sid0 = src_sid[list(src_sid.keys())[0]]  # first key/first file; used to extract some common metadata
     swath_id = re.search('_(IW|EW|S[1-6])_', os.path.basename(sid0.file)).group().replace('_', '')
     
-    ref_tif = finder(target, ['[hv]{2}-g-lin.tif$'], regex=True)[0]
+    ref_tif = finder(target, ['[hv]{2}-[gs]-lin.tif$'], regex=True)[0]
     np_tifs = finder(target, ['-np-[hv]{2}.tif$'], regex=True)
     ei_tif = finder(target, ['-ei.tif$'], regex=True)[0]
     

--- a/S1_NRB/metadata/extract.py
+++ b/S1_NRB/metadata/extract.py
@@ -553,7 +553,7 @@ def meta_dict(config, target, src_ids, rtc_dir, proc_time, start, stop, compress
     meta['prod']['azimuthNumberOfLooks'] = prod_meta['ML_nAzLooks']
     meta['prod']['backscatterConvention'] = 'linear power'
     meta['prod']['backscatterConversionEq'] = '10*log10(DN)'
-    meta['prod']['backscatterMeasurement'] = 'gamma0'
+    meta['prod']['backscatterMeasurement'] = 'gamma0' if re.search('g-lin', ref_tif) else 'sigma0'
     meta['prod']['card4l-link'] = 'https://ceos.org/ard/files/PFS/NRB/v5.5/CARD4L-PFS_NRB_v5.5.pdf'
     meta['prod']['card4l-version'] = '5.5'
     meta['prod']['crsEPSG'] = str(prod_meta['epsg'])
@@ -594,7 +594,7 @@ def meta_dict(config, target, src_ids, rtc_dir, proc_time, start, stop, compress
     meta['prod']['griddingConvention'] = 'Military Grid Reference System (MGRS)'
     meta['prod']['licence'] = config['meta']['licence']
     meta['prod']['mgrsID'] = prod_meta['mgrsID']
-    meta['prod']['NRApplied'] = True if len(np_tifs) > 0 else False
+    meta['prod']['NRApplied'] = True
     meta['prod']['NRAlgorithm'] = 'https://sentinel.esa.int/documents/247904/2142675/Thermal-Denoising-of-Products-' \
                                   'Generated-by-Sentinel-1-IPF' if meta['prod']['NRApplied'] else None
     meta['prod']['numberOfAcquisitions'] = str(len(src_sid))

--- a/S1_NRB/metadata/extract.py
+++ b/S1_NRB/metadata/extract.py
@@ -391,7 +391,8 @@ def get_header_size(tif):
 def calc_geolocation_accuracy(swath_identifier, ei_tif, dem_type, etad):
     """
     Calculates the radial root mean square error, which is a target requirement of the CARD4L NRB specification
-    (Item 4.3). For more information see: https://s1-nrb.readthedocs.io/en/latest/general/geoaccuracy.html
+    (Item 4.3). For more information see: https://s1-nrb.readthedocs.io/en/latest/general/geoaccuracy.html.
+    Currently only the Copernicus DEM is supported.
     
     Parameters
     ----------
@@ -406,8 +407,8 @@ def calc_geolocation_accuracy(swath_identifier, ei_tif, dem_type, etad):
     
     Returns
     -------
-    rmse_planar: float
-        The calculated rRMSE value rounded to two decimal places.
+    rmse_planar: float or None
+        The calculated rRMSE value rounded to two decimal places or None if a DEM other than Copernicus is used.
     """
     if 'copernicus' not in dem_type.lower():
         return None

--- a/S1_NRB/metadata/mapping.py
+++ b/S1_NRB/metadata/mapping.py
@@ -17,6 +17,10 @@ ITEM_MAP = {'vv-g-lin': {'z_error': 1e-4},
             'vh-g-lin': {'z_error': 1e-4},
             'hh-g-lin': {'z_error': 1e-4},
             'hv-g-lin': {'z_error': 1e-4},
+            'vv-s-lin': {'z_error': 1e-4},
+            'vh-s-lin': {'z_error': 1e-4},
+            'hh-s-lin': {'z_error': 1e-4},
+            'hv-s-lin': {'z_error': 1e-4},
             'ei': {'z_error': 1e-3},
             'em': {'z_error': 1e-3},
             'dm': {'z_error': 0.0},
@@ -27,7 +31,8 @@ ITEM_MAP = {'vv-g-lin': {'z_error': 1e-4},
             'np-vv': {'z_error': 2e-5},
             'np-vh': {'z_error': 2e-5},
             'np-hh': {'z_error': 2e-5},
-            'np-hv': {'z_error': 2e-5}}
+            'np-hv': {'z_error': 2e-5},
+            'sg': {'z_error': 1e-4}}
 
 # Source data resolution
 # https://sentinels.copernicus.eu/web/sentinel/technical-guides/sentinel-1-sar/products-algorithms/level-1-algorithms/single-look-complex
@@ -140,7 +145,11 @@ SAMPLE_MAP = {'-dm.tif': {'type': 'Mask',
               '-np-[vh]{2}.tif': {'type': 'Sigma-0',
                                   'unit': 'dB',
                                   'role': 'noise-power',
-                                  'title': 'Noise Power'}}
+                                  'title': 'Noise Power'},
+              '-sg.tif': {'type': 'Ratio',
+                          'unit': None,
+                          'role': 'sigma-gamma-ratio',
+                          'title': 'Sigma0 ellipsoidal to gamma0 RTC ratio'}}
 
 # https://sentinel.esa.int/documents/247904/1653442/Guide-to-Sentinel-1-Geocoding.pdf
 SLC_ACC_MAP = {'SM': {'ALE': {'rg': -3.02,

--- a/S1_NRB/metadata/stac.py
+++ b/S1_NRB/metadata/stac.py
@@ -192,8 +192,9 @@ def product_json(meta, target, tifs, exist_ok=False):
         if 'measurement' in asset:
             pattern = '(?P<key>(?P<pol>[vhc]{2})-(?P<nought>[gs])-(?P<scaling>lin|log))'
             info = re.search(pattern, asset).groupdict()
+            key = info['key']
             
-            if re.search('cc-[gs]-lin', info['key']):
+            if re.search('cc-[gs]-lin', key):
                 pols = meta['common']['polarisationChannels']
                 co = pols.pop(0) if pols[0][0] == pols[0][1] else pols.pop(1)
                 cross = pols[0]

--- a/S1_NRB/nrb.py
+++ b/S1_NRB/nrb.py
@@ -26,7 +26,7 @@ from S1_NRB.snap import find_datasets
 
 def format(config, scenes, datadir, outdir, tile, extent, epsg, wbm=None,
            dem_type=None, multithread=True, compress=None,
-           overviews=None, kml=None, annotation=None):
+           overviews=None, kml=None, annotation=None, update=False):
     """
     Finalizes the generation of Sentinel-1 NRB products after RTC processing has finished. This includes the following:
     - Creating all measurement and annotation datasets in Cloud Optimized GeoTIFF (COG) format
@@ -78,6 +78,8 @@ def format(config, scenes, datadir, outdir, tile, extent, epsg, wbm=None,
         - np: noise power (NESZ, per polarization)
         - gs: gamma-sigma ratio: sigma0 RTC / gamma0 RTC
         - sg: sigma-gamma ratio: gamma0 RTC / sigma0 ellipsoidal
+    update: bool
+        modify existing products so that only missing files are re-created?
 
     Returns
     -------
@@ -141,11 +143,10 @@ def format(config, scenes, datadir, outdir, tile, extent, epsg, wbm=None,
     skeleton_dir = '{mission}_{mode}_NRB__1S{polarization}_{start}_{orbitnumber:06}_{datatake:0>6}_{tile}_{id}'
     skeleton_files = '{mission}-{mode}-nrb-{start}-{orbitnumber:06}-{datatake:0>6}-{tile}-{suffix}.tif'
     
-    modify_existing = True  # modify existing products so that only missing files are re-created
     nrb_base = skeleton_dir.format(**meta)
     existing = finder(outdir, [nrb_base.replace(product_id, '*')], foldermode=2)
     if len(existing) > 0:
-        if not modify_existing:
+        if not update:
             return 'Already processed - Skip!'
         else:
             nrb_dir = existing[0]

--- a/S1_NRB/nrb.py
+++ b/S1_NRB/nrb.py
@@ -519,6 +519,7 @@ def create_vrt(src, dst, fun, relpaths=False, scale=None, offset=None, args=None
         srcfiles = tree.xpath('//SourceFilename[@relativeToVRT="0"]')
         for srcfile in srcfiles:
             repl = os.path.relpath(srcfile.text, start=os.path.dirname(dst))
+            repl = repl.replace('\\', '/')
             srcfile.text = repl
             srcfile.attrib['relativeToVRT'] = '1'
     

--- a/S1_NRB/processor.py
+++ b/S1_NRB/processor.py
@@ -27,6 +27,7 @@ def main(config_file, section_name='PROCESSING', debug=False):
     debug: bool
         Set pyroSAR logging level to DEBUG? Default is False.
     """
+    update = False  # update existing products? Internal development flag.
     config = get_config(config_file=config_file, proc_section=section_name)
     logger = anc.set_logging(config=config, debug=debug)
     geocode_prms = snap_conf(config=config)
@@ -101,13 +102,13 @@ def main(config_file, section_name='PROCESSING', debug=False):
             tmp_dir_scene = os.path.join(config['tmp_dir'], scene_base)
             
             print(f'###### [    RTC] Scene {i + 1}/{len(scenes)}: {scene.scene}')
-            if os.path.isdir(out_dir_scene):
+            if os.path.isdir(out_dir_scene) and not update:
                 msg = 'Already processed - Skip!'
                 print('### ' + msg)
                 anc.log(handler=logger, mode='info', proc_step='GEOCODE', scenes=scene.scene, msg=msg)
                 continue
             else:
-                os.makedirs(out_dir_scene)
+                os.makedirs(out_dir_scene, exist_ok=True)
                 os.makedirs(tmp_dir_scene, exist_ok=True)
             ############################################################################################################
             # Preparation of DEM for SAR processing
@@ -239,7 +240,8 @@ def main(config_file, section_name='PROCESSING', debug=False):
                     msg = nrb.format(config=config, scenes=scenes_fnames, datadir=config['rtc_dir'],
                                      outdir=outdir, tile=tile.mgrs, extent=extent, epsg=epsg,
                                      wbm=fname_wbm, dem_type=nrb_dem_type, kml=config['kml_file'],
-                                     multithread=gdal_prms['multithread'], annotation=config['annotation'])
+                                     multithread=gdal_prms['multithread'], annotation=config['annotation'],
+                                     update=update)
                     if msg == 'Already processed - Skip!':
                         print('### ' + msg)
                     anc.log(handler=logger, mode='info', proc_step='NRB', scenes=scenes_fnames, msg=msg)

--- a/S1_NRB/processor.py
+++ b/S1_NRB/processor.py
@@ -163,7 +163,7 @@ def main(config_file, section_name='PROCESSING', debug=False):
             # main processing routine
             start_time = time.time()
             try:
-                snap.process(scene=scene.scene, outdir=config['rtc_dir'],
+                snap.process(scene=scene.scene, outdir=config['rtc_dir'], convention='gamma',
                              tmpdir=config['tmp_dir'], kml=config['kml_file'],
                              dem=fname_dem, neighbors=neighbors,
                              rlks=rlks, azlks=azlks, **geocode_prms)

--- a/S1_NRB/processor.py
+++ b/S1_NRB/processor.py
@@ -162,10 +162,30 @@ def main(config_file, section_name='PROCESSING', debug=False):
             ############################################################################################################
             # main processing routine
             start_time = time.time()
+            lookup = {'dm': 'layoverShadowMask',
+                      'ei': 'incidenceAngleFromEllipsoid',
+                      'gs': 'gammaSigmaRatio',
+                      'li': 'localIncidenceAngle',
+                      'lc': 'scatteringArea',
+                      'np': 'NESZ',
+                      'sg': 'sigmaGammaRatio'}
+            if config['annotation'] is None:
+                export_extra = None
+            else:
+                export_extra = []
+                for annotation in config['annotation']:
+                    if annotation == 'gs' and config['measurement'] != 'gamma':
+                        continue
+                    if annotation == 'sg' and config['measurement'] != 'sigma':
+                        continue
+                    if annotation in lookup.keys():
+                        export_extra.append(lookup[annotation])
             try:
-                snap.process(scene=scene.scene, outdir=config['rtc_dir'], convention='gamma',
+                snap.process(scene=scene.scene, outdir=config['rtc_dir'],
+                             measurement=config['measurement'],
                              tmpdir=config['tmp_dir'], kml=config['kml_file'],
                              dem=fname_dem, neighbors=neighbors,
+                             export_extra=export_extra,
                              rlks=rlks, azlks=azlks, **geocode_prms)
                 t = round((time.time() - start_time), 2)
                 anc.log(handler=logger, mode='info', proc_step='RTC', scenes=scene.scene, msg=t)
@@ -219,7 +239,7 @@ def main(config_file, section_name='PROCESSING', debug=False):
                     msg = nrb.format(config=config, scenes=scenes_fnames, datadir=config['rtc_dir'],
                                      outdir=outdir, tile=tile.mgrs, extent=extent, epsg=epsg,
                                      wbm=fname_wbm, dem_type=nrb_dem_type, kml=config['kml_file'],
-                                     multithread=gdal_prms['multithread'])
+                                     multithread=gdal_prms['multithread'], annotation=config['annotation'])
                     if msg == 'Already processed - Skip!':
                         print('### ' + msg)
                     anc.log(handler=logger, mode='info', proc_step='NRB', scenes=scenes_fnames, msg=msg)

--- a/S1_NRB/snap.py
+++ b/S1_NRB/snap.py
@@ -470,7 +470,7 @@ def geo(*src, dst, workflow, spacing, crs, geometry=None, buffer=0.01,
     gpt(xmlfile=workflow, tmpdir=os.path.dirname(dst))
 
 
-def process(scene, outdir, convention, spacing, kml, dem,
+def process(scene, outdir, measurement, spacing, kml, dem,
             dem_resampling_method='BILINEAR_INTERPOLATION',
             img_resampling_method='BILINEAR_INTERPOLATION',
             rlks=None, azlks=None, tmpdir=None, export_extra=None,
@@ -485,8 +485,8 @@ def process(scene, outdir, convention, spacing, kml, dem,
         The SAR scene file name.
     outdir: str
         The output directory for storing the final results.
-    convention: {'sigma', 'gamma'}
-        the backscatter convention:
+    measurement: {'sigma', 'gamma'}
+        the backscatter measurement convention:
         
         - gamma: RTC gamma nought (gamma^0_T)
         - sigma: ellipsoidal sigmal nought (sigma^0_E)
@@ -552,8 +552,8 @@ def process(scene, outdir, convention, spacing, kml, dem,
     >>> snap.process(scene=scene, outdir=outdir, spacing=spacing, kml=kml, dem=dem,
     >>>              rlks=rlks, azlks=azlks, export_extra=export_extra)
     """
-    if convention not in ['gamma', 'sigma']:
-        raise RuntimeError("'convention' must either be 'gamma' or 'sigma'")
+    if measurement not in ['gamma', 'sigma']:
+        raise RuntimeError("'measurement' must either be 'gamma' or 'sigma'")
     if export_extra is None:
         export_extra = []
     if tmpdir is None:
@@ -570,7 +570,7 @@ def process(scene, outdir, convention, spacing, kml, dem,
     id = identify(scene)
     workflows = []
     
-    apply_rtc = convention == 'gamma' \
+    apply_rtc = measurement == 'gamma' \
                 or 'sigmaGammaRatio' in export_extra \
                 or 'gammaSigmaRatio' in export_extra
     ############################################################################
@@ -676,7 +676,7 @@ def process(scene, outdir, convention, spacing, kml, dem,
             scene1 = identify(out_mli)
             pols = scene1.polarizations
             bands0 = ['NESZ_{}'.format(pol) for pol in pols]
-            if convention == 'gamma':
+            if measurement == 'gamma':
                 bands1 = ['Gamma0_{}'.format(pol) for pol in pols]
             else:
                 bands0.extend(['Sigma0_{}'.format(pol) for pol in pols])

--- a/S1_NRB/snap.py
+++ b/S1_NRB/snap.py
@@ -642,7 +642,7 @@ def process(scene, outdir, convention, spacing, kml, dem,
                     src_gamma=out_rtc)
     ############################################################################
     # geocoding
-    with id.bbox() as geom:
+    with id.geometry() as geom:
         tiles = tile_from_aoi(vector=geom, kml=kml)
     
     for zone, group in itertools.groupby(tiles, lambda x: x[:2]):

--- a/S1_NRB/snap.py
+++ b/S1_NRB/snap.py
@@ -738,15 +738,20 @@ def find_datasets(scene, outdir, epsg):
          - hv-g-lin: gamma nought RTC backscatter HV polarization
          - vh-g-lin: gamma nought RTC backscatter VH polarization
          - vv-g-lin: gamma nought RTC backscatter VV polarization
+         - hh-s-lin: sigma nought ellipsoidal backscatter HH polarization
+         - hv-s-lin: sigma nought ellipsoidal backscatter HV polarization
+         - vh-s-lin: sigma nought ellipsoidal backscatter VH polarization
+         - vv-s-lin: sigma nought ellipsoidal backscatter VV polarization
          - dm: layover-shadow data mask
          - ei: ellipsoidal incident angle
          - gs: gamma-sigma ratio
          - lc: local contributing area (aka scattering area)
          - li: local incident angle
-         - np-hh: noise power HH polarization
-         - np-hv: noise power HV polarization
-         - np-vh: noise power VH polarization
-         - np-vv: noise power VV polarization
+         - sg: sigma-gamma ratio
+         - np-hh: NESZ HH polarization
+         - np-hv: NESZ HV polarization
+         - np-vh: NESZ VH polarization
+         - np-vv: NESZ VV polarization
     """
     basename = os.path.splitext(os.path.basename(scene))[0]
     scenedir = os.path.join(outdir, basename)
@@ -757,17 +762,19 @@ def find_datasets(scene, outdir, epsg):
               'ei': r'incidenceAngleFromEllipsoid\.img$',
               'gs': r'gammaSigmaRatio_[VH]{2}\.img$',
               'lc': r'simulatedImage_[VH]{2}\.img$',
-              'li': r'localIncidenceAngle\.img$'}
+              'li': r'localIncidenceAngle\.img$',
+              'sg': r'sigmaGammaRatio_[VH]{2}\.img$'}
     out = {}
     for key, pattern in lookup.items():
         match = finder(target=subdir, matchlist=[pattern], regex=True)
         if len(match) > 0:
             out[key] = match[0]
-    pattern = r'Gamma0_(?P<pol>[VH]{2})\.img$'
-    gamma = finder(target=subdir, matchlist=[pattern], regex=True)
-    for item in gamma:
-        pol = re.search(pattern, item).group('pol')
-        out[f'{pol.lower()}-g-lin'] = item
+    pattern = r'(?P<bsc>Gamma0|Sigma0)_(?P<pol>[VH]{2})\.img$'
+    backscatter = finder(target=subdir, matchlist=[pattern], regex=True)
+    for item in backscatter:
+        pol = re.search(pattern, item).group('pol').lower()
+        bsc = re.search(pattern, item).group('bsc')[0].lower()
+        out[f'{pol}-{bsc}-lin'] = item
     pattern = r'NESZ_(?P<pol>[VH]{2})\.img$'
     nesz = finder(target=subdir, matchlist=[pattern], regex=True)
     for item in nesz:

--- a/S1_NRB/snap.py
+++ b/S1_NRB/snap.py
@@ -62,7 +62,7 @@ def mli(src, dst, workflow, spacing=None, rlks=None, azlks=None):
         gpt(xmlfile=workflow, tmpdir=os.path.dirname(dst))
 
 
-def pre(src, dst, workflow, allow_res_osv=True):
+def pre(src, dst, workflow, allow_res_osv=True, output_noise=True, output_beta0=True):
     """
     General SAR preprocessing. The following operators are used (optional steps in brackets):
     Apply-Orbit-File(->Remove-GRD-Border-Noise)->Calibration->ThermalNoiseRemoval(->TOPSAR-Deburst)
@@ -77,6 +77,10 @@ def pre(src, dst, workflow, allow_res_osv=True):
         the output SNAP XML workflow filename.
     allow_res_osv: bool
         Also allow the less accurate RES orbit files to be used?
+    output_noise: bool
+        output the noise power images?
+    output_beta0: bool
+        output beta nought backscatter needed for RTC?
 
     Returns
     -------
@@ -107,13 +111,13 @@ def pre(src, dst, workflow, allow_res_osv=True):
     cal = parse_node('Calibration')
     wf.insert_node(cal, before=last.id)
     cal.parameters['selectedPolarisations'] = polarizations
-    cal.parameters['outputBetaBand'] = True
+    cal.parameters['outputBetaBand'] = output_beta0
     cal.parameters['outputSigmaBand'] = True
     cal.parameters['outputGammaBand'] = False
     ############################################
     tnr = parse_node('ThermalNoiseRemoval')
     wf.insert_node(tnr, before=cal.id)
-    tnr.parameters['outputNoise'] = True
+    tnr.parameters['outputNoise'] = output_noise
     last = tnr
     ############################################
     if scene.product == 'SLC' and scene.acquisition_mode in ['EW', 'IW']:

--- a/S1_NRB/snap.py
+++ b/S1_NRB/snap.py
@@ -507,7 +507,8 @@ def process(scene, outdir, convention, spacing, kml, dem,
     tmpdir: str or None
         Path to a temporary directory for intermediate products.
     export_extra: list[str] or None
-        A list of ancillary layers to create. Options:
+        A list of ancillary layers to create. Default None: do not create any ancillary layers.
+        Options:
         
          - DEM
          - gammaSigmaRatio: sigma^0_T / gamma^0_T
@@ -552,6 +553,8 @@ def process(scene, outdir, convention, spacing, kml, dem,
     """
     if convention not in ['gamma', 'sigma']:
         raise RuntimeError("'convention' must either be 'gamma' or 'sigma'")
+    if export_extra is None:
+        export_extra = []
     if tmpdir is None:
         tmpdir = outdir
     basename = os.path.splitext(os.path.basename(scene))[0]
@@ -596,6 +599,7 @@ def process(scene, outdir, convention, spacing, kml, dem,
         out_buffer_wf = out_buffer.replace('.dim', '.xml')
         workflows.append(out_buffer_wf)
         if not os.path.isfile(out_buffer):
+            print('### buffering scene with neighboring acquisitions')
             grd_buffer(src=out_pre, dst=out_buffer, workflow=out_buffer_wf,
                        neighbors=out_pre_neighbors)
         out_pre = out_buffer

--- a/S1_NRB/snap.py
+++ b/S1_NRB/snap.py
@@ -62,7 +62,8 @@ def mli(src, dst, workflow, spacing=None, rlks=None, azlks=None):
         gpt(xmlfile=workflow, tmpdir=os.path.dirname(dst))
 
 
-def pre(src, dst, workflow, allow_res_osv=True, output_noise=True, output_beta0=True):
+def pre(src, dst, workflow, allow_res_osv=True, osv_continue_on_fail=False,
+        output_noise=True, output_beta0=True):
     """
     General SAR preprocessing. The following operators are used (optional steps in brackets):
     Apply-Orbit-File(->Remove-GRD-Border-Noise)->Calibration->ThermalNoiseRemoval(->TOPSAR-Deburst)
@@ -77,6 +78,8 @@ def pre(src, dst, workflow, allow_res_osv=True, output_noise=True, output_beta0=
         the output SNAP XML workflow filename.
     allow_res_osv: bool
         Also allow the less accurate RES orbit files to be used?
+    osv_continue_on_fail: bool
+        Continue processing if no OSV file can be downloaded or raise an error?
     output_noise: bool
         output the noise power images?
     output_beta0: bool
@@ -98,7 +101,8 @@ def pre(src, dst, workflow, allow_res_osv=True, output_noise=True, output_beta0=
     wf.insert_node(read)
     ############################################
     orb = orb_parametrize(scene=scene, formatName='SENTINEL-1',
-                          allow_RES_OSV=allow_res_osv)
+                          allow_RES_OSV=allow_res_osv,
+                          continueOnFail=osv_continue_on_fail)
     wf.insert_node(orb, before=read.id)
     last = orb
     ############################################

--- a/S1_NRB/snap.py
+++ b/S1_NRB/snap.py
@@ -796,10 +796,13 @@ def get_metadata(scene, outdir):
     scenedir = os.path.join(outdir, basename)
     rlks = azlks = 1
     wf_mli = finder(scenedir, ['*mli.xml'])
-    if len(wf_mli) > 0:
-        wf = parse_recipe(wf_mli)
+    if len(wf_mli) == 1:
+        wf = parse_recipe(wf_mli[0])
         if 'Multilook' in wf.operators:
             rlks = int(wf['Multilook'].parameters['nRgLooks'])
             azlks = int(wf['Multilook'].parameters['nAzLooks'])
+    elif len(wf_mli) > 1:
+        msg = 'found multiple multi-looking workflows:\n{}'
+        raise RuntimeError(msg.format('\n'.join(wf_mli)))
     return {'azlks': azlks,
             'rlks': rlks}

--- a/config.ini
+++ b/config.ini
@@ -63,6 +63,26 @@ dem_type = Copernicus 30m Global DEM
 # Temporarily changes GDAL_NUM_THREADS during processing. Will be reset after processing has finished.
 gdal_threads = 4
 
+# The backscatter measurement convention. Either gamma nought RTC or ellipsoidal sigma nought.
+# Other conventions will be included in the product as VRTs using the annotation layers gs and sg.
+# OPTIONS: gamma | sigma
+measurement = gamma
+
+# list of annotation layers to write to the final NRB product. OPTIONS:
+# dm: data mask (four masks: not layover not shadow, layover, shadow, ocean water)
+# ei: ellipsoidal incident angle (needed for computing geolocation accuracy)
+# em: digital elevation model
+# id: acquisition ID image (source scene ID per pixel)
+# lc: RTC local contributing area
+# li: local incident angle
+# np: noise power (NESZ, per polarization)
+# gs: gamma-sigma ratio: sigma0 RTC / gamma0 RTC (ignored if measurement is not gamma)
+# sg: sigma-gamma ratio: gamma0 RTC / sigma0 ellipsoidal (ignored if measurement is not sigma)
+# Use one of the following to create no annotation layer:
+# annotation =
+# annotation = None
+annotation = dm, ei, em, id, lc, li, np, gs
+
 # Should ETAD correction be performed on SLCs? If [etad] is False, [etad_dir] will be ignored,
 # otherwise [etad_dir] is searched recursively for ETAD products matching the defined SLCs.
 etad = False

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -44,8 +44,10 @@ SNAP
 
         process
         geo
+        grd_buffer
         gsr
         mli
+        pre
         rtc
 
     .. rubric:: ancillary functions
@@ -129,10 +131,15 @@ Ancillary Functions
     .. autosummary::
         :nosignatures:
 
+        check_acquisition_completeness
+        check_scene_consistency
+        check_spacing
         generate_unique_id
         get_max_ext
+        group_by_time
         log
         set_logging
+        vrt_add_overviews
 
 Metadata
 --------

--- a/docs/general/folderstructure.rst
+++ b/docs/general/folderstructure.rst
@@ -1,7 +1,9 @@
 Folder Structure
 ================
 
-The following describes the structure created to store intermediate and final files during a processor run.
+The following demonstrates a possible structure created to store intermediate and final files during a processor run.
+The listed files describe the output of the user configuration parameter ``measurement`` set to ``gamma``
+and all output annotation layers enabled (``annotation = dm, ei, em, id, lc, li, np, gs``).
 The structure is based on the default configuration defined in the `config.ini` file and can be modified by a user.
 Folders are highlighted in bold.
 
@@ -54,6 +56,7 @@ Folders are highlighted in bold.
 
                                             | s1a-iw-nrb-20200103t170705-030639-0382d5-32tps-dm.tif
                                             | s1a-iw-nrb-20200103t170705-030639-0382d5-32tps-ei.tif
+                                            | s1a-iw-nrb-20200103t170705-030639-0382d5-32tps-em.tif
                                             | s1a-iw-nrb-20200103t170705-030639-0382d5-32tps-gs.tif
                                             | s1a-iw-nrb-20200103t170705-030639-0382d5-32tps-id.tif
                                             | s1a-iw-nrb-20200103t170705-030639-0382d5-32tps-lc.tif
@@ -116,6 +119,7 @@ Folders are highlighted in bold.
                             | S1A_IW_SLC__1SDV_20200103T170700_20200103T170727_030639_0382D5_6A12_geo_32632.xml
                             | S1A_IW_SLC__1SDV_20200103T170700_20200103T170727_030639_0382D5_6A12_gsr.xml
                             | S1A_IW_SLC__1SDV_20200103T170700_20200103T170727_030639_0382D5_6A12_mli.xml
+                            | S1A_IW_SLC__1SDV_20200103T170700_20200103T170727_030639_0382D5_6A12_pre.xml
                             | S1A_IW_SLC__1SDV_20200103T170700_20200103T170727_030639_0382D5_6A12_rtc.xml
 
                             ...
@@ -141,6 +145,7 @@ Folders are highlighted in bold.
                             | S1A_IW_ETA__AXDV_20200103T170700_20200103T170727_030639_0382D5_256B.SAFE
                             | S1A_IW_SLC__1SDV_20200103T170700_20200103T170727_030639_0382D5_6A12_gsr.data
                             | S1A_IW_SLC__1SDV_20200103T170700_20200103T170727_030639_0382D5_6A12_mli.data
+                            | S1A_IW_SLC__1SDV_20200103T170700_20200103T170727_030639_0382D5_6A12_pre.data
                             | S1A_IW_SLC__1SDV_20200103T170700_20200103T170727_030639_0382D5_6A12_rtc.data
                             | S1A_IW_SLC__1SDV_20200103T170700_20200103T170727_030639_0382D5_6A12_DEM_EEA10.tif
                             | S1A_IW_SLC__1SDV_20200103T170700_20200103T170727_030639_0382D5_6A12_DEM_EEA10.vrt
@@ -148,6 +153,8 @@ Folders are highlighted in bold.
                             | S1A_IW_SLC__1SDV_20200103T170700_20200103T170727_030639_0382D5_6A12_gsr.xml
                             | S1A_IW_SLC__1SDV_20200103T170700_20200103T170727_030639_0382D5_6A12_mli.dim
                             | S1A_IW_SLC__1SDV_20200103T170700_20200103T170727_030639_0382D5_6A12_mli.xml
+                            | S1A_IW_SLC__1SDV_20200103T170700_20200103T170727_030639_0382D5_6A12_pre.dim
+                            | S1A_IW_SLC__1SDV_20200103T170700_20200103T170727_030639_0382D5_6A12_pre.xml
                             | S1A_IW_SLC__1SDV_20200103T170700_20200103T170727_030639_0382D5_6A12_rtc.dim
                             | S1A_IW_SLC__1SDV_20200103T170700_20200103T170727_030639_0382D5_6A12_rtc.xml
                             | ...


### PR DESCRIPTION
- choose between gamma0 RTC ( $\gamma^0_T$ ) and ellipsoidal sigma0 ( $\sigma^0_E$ ) using new configuration parameter `measurement`
- control the annotation layers to add to the product via new configuration parameter `annotation`
- new annotation layer sigma-gamma ratio ( $\gamma^0_T / \sigma^0_E$ ) intended for converting to $\gamma^0_T$ if the base measurement convention is $\sigma^0_E$