### PR TITLE
SNAP RTC: increase DEM oversampling by a factor of two

### DIFF
--- a/S1_NRB/snap.py
+++ b/S1_NRB/snap.py
@@ -197,7 +197,7 @@ def grd_buffer(src, dst, workflow, neighbors, buffer=10):
 
 
 def rtc(src, dst, workflow, dem, dem_resampling_method='BILINEAR_INTERPOLATION',
-        sigma0=True, scattering_area=True):
+        sigma0=True, scattering_area=True, dem_oversampling_multiple=2):
     """
     Radiometric Terrain Flattening.
     
@@ -217,6 +217,10 @@ def rtc(src, dst, workflow, dem, dem_resampling_method='BILINEAR_INTERPOLATION',
         output sigma0 RTC backscatter?
     scattering_area: bool
         output scattering area image?
+    dem_oversampling_multiple: int
+        a factor to multiply the DEM oversampling factor computed by SNAP.
+        The SNAP default of 1 has been found to be insufficient with stripe
+        artifacts remaining in the image.
 
     Returns
     -------
@@ -244,6 +248,7 @@ def rtc(src, dst, workflow, dem, dem_resampling_method='BILINEAR_INTERPOLATION',
     with Raster(dem) as ras:
         tf.parameters['externalDEMNoDataValue'] = ras.nodata
     tf.parameters['demResamplingMethod'] = dem_resampling_method
+    tf.parameters['oversamplingMultiple'] = dem_oversampling_multiple
     last = tf
     ############################################
     write = parse_node('Write')


### PR DESCRIPTION
This increases the default value for the SNAP `Terrain-Flattening` parameter `oversamplingMultiple` from 1 to 2 to remove artifacts. The oversampling factor determined by SNAP is not high enough and is now multiplied by 2.
The value can be changed via a new argument `dem_oversampling_multiple` in function [S1_NRB.snap.rtc](https://s1-nrb--78.org.readthedocs.build/en/78/api.html#S1_NRB.snap.rtc).  
Comparsion of scattering area images from processing an EW scene with 40 m pixel spacing and a Copernicus 30 m DEM as input:
| before              | after              |
|----------------------|----------------------|
| ![Screenshot 2023-02-08 104714](https://user-images.githubusercontent.com/18419439/217497579-60c24644-70bd-4966-a3ac-49b3c27b84f1.png)        | ![Screenshot 2023-02-08 104753](https://user-images.githubusercontent.com/18419439/217497675-70a96f2d-1faf-454e-9690-393b1ab6c2d4.png)               |
