### PR TITLE
nrb.format: do not hardcode src_nodata and read it from the data instead

### DIFF
--- a/S1_NRB/nrb.py
+++ b/S1_NRB/nrb.py
@@ -93,7 +93,6 @@ def format(config, scenes, datadir, outdir, tile, extent, epsg, wbm=None,
     ovr_resampling = 'AVERAGE'
     driver = 'COG'
     blocksize = 512
-    src_nodata = 0
     dst_nodata_float = -9999.0
     dst_nodata_byte = 255
     vrt_nodata = 'nan'  # was found necessary for proper calculation of statistics in QGIS
@@ -203,7 +202,7 @@ def format(config, scenes, datadir, outdir, tile, extent, epsg, wbm=None,
             # modify temporary VRT to make sure overview levels and resampling are properly applied
             vrt_add_overviews(vrt=source, overviews=overviews, resampling=ovr_resampling)
             
-            options = {'format': driver, 'outputBounds': bounds, 'srcNodata': src_nodata,
+            options = {'format': driver, 'outputBounds': bounds,
                        'dstNodata': dst_nodata_float, 'multithread': multithread,
                        'creationOptions': write_options[key]}
             


### PR DESCRIPTION
The SNAP ENVI files (inside the BEAM-DIMAP structure) do not have a nodata metadata value. Therefore, the value 0 was hardcoded in the function `nrb.format`. Now, the nodata value is directly written to the ENVI HDR files during SNAP processing so it can be read by `gdalwarp` when converting the images to their final format. The hardcoded value can thus be removed.