### PR TITLE
enable configuration via command line arguments

### DIFF
--- a/S1_NRB/ancillary.py
+++ b/S1_NRB/ancillary.py
@@ -302,6 +302,11 @@ def _log_process_config(logger, config):
     mindate             {config['mindate'].isoformat()}
     maxdate             {config['maxdate'].isoformat()}
     acq_mode            {config['acq_mode']}
+    product             {config['product']}
+    measurement         {config.get('measurement')}
+    annotation          {config.get('annotation')}
+    dem_type            {config.get('dem_type')}
+    etad                {config.get('etad')}
     
     work_dir            {config['work_dir']}
     scene_dir           {config['scene_dir']}
@@ -310,9 +315,9 @@ def _log_process_config(logger, config):
     nrb_dir             {config['nrb_dir']}
     wbm_dir             {config['wbm_dir']}
     log_dir             {config['log_dir']}
+    etad_dir            {config['etad_dir']}
     db_file             {config['db_file']}
     kml_file            {config['kml_file']}
-    dem_type            {config.get('dem_type')}
     gdal_threads        {config.get('gdal_threads')}
     
     ====================================================================================================================

--- a/S1_NRB/cli.py
+++ b/S1_NRB/cli.py
@@ -25,6 +25,21 @@ def cli(ctx, config_file, section, debug, version):
     file except the acquisition mode and the annotation layers:
     
     s1_nrb -c config.ini --acq_mode IW --annotation dm,id
+    
+    \b
+    The following defaults are set:
+    - annotation (measurement=gamma): dm,ei,id,lc,li,np,gs
+    - annotation (measurement=sigma): dm,ei,id,lc,li,np,sg
+    - dem_type:     Copernicus 30m Global DEM
+    - etad:         False
+    - etad_dir:     None
+    - gdal_threads: 4
+    - log_dir:      LOG
+    - measurement:  gamma
+    - nrb_dir:      NRB
+    - rtc_dir:      RTC
+    - tmp_dir:      TMP
+    - wbm_dir:      WBM
     """
     import S1_NRB
     if version:

--- a/S1_NRB/cli.py
+++ b/S1_NRB/cli.py
@@ -1,7 +1,11 @@
 import click
 
 
-@click.command()
+@click.command(name='s1_nrb',
+               context_settings=dict(
+                   ignore_unknown_options=True,
+                   allow_extra_args=True, )
+               )
 @click.option('--config-file', '-c', required=False, type=click.Path(),
               help='Full path to an INI-style configuration text file.')
 @click.option('--section', '-s', required=False, type=str, default='PROCESSING', show_default=True,
@@ -9,10 +13,21 @@ import click
 @click.option('--debug', is_flag=True,
               help='Print debugging information for pyroSAR modules.')
 @click.option('--version', is_flag=True,
-              help='Print S1_NRB version information. Overrides all other arguments.')
-def cli(config_file, section, debug, version):
+              help='Print S1_NRB version information and exit. Overrides all other arguments.')
+@click.pass_context
+def cli(ctx, config_file, section, debug, version):
+    """
+    Central S1_NRB processing command.
+    
+    Additional options can be passed to override individual processing parameters
+    in the configuration file. For example, to read all values from the configuration
+    file except the acquisition mode and the annotation layers:
+    
+    s1_nrb -c config.ini --acq_mode IW --annotation dm,id
+    """
     import S1_NRB
     if version:
         print(S1_NRB.__version__)
     else:
-        S1_NRB.process(config_file=config_file, section_name=section, debug=debug)
+        extra = {ctx.args[i][2:]: ctx.args[i + 1] for i in range(0, len(ctx.args), 2)}
+        S1_NRB.process(config_file=config_file, section_name=section, debug=debug, **extra)

--- a/S1_NRB/cli.py
+++ b/S1_NRB/cli.py
@@ -2,6 +2,7 @@ import click
 
 
 @click.command(name='s1_nrb',
+               no_args_is_help=True,
                context_settings=dict(
                    ignore_unknown_options=True,
                    allow_extra_args=True, )

--- a/S1_NRB/cli.py
+++ b/S1_NRB/cli.py
@@ -28,18 +28,24 @@ def cli(ctx, config_file, section, debug, version):
     
     \b
     The following defaults are set:
+    (processing section)
     - annotation (measurement=gamma): dm,ei,id,lc,li,np,gs
     - annotation (measurement=sigma): dm,ei,id,lc,li,np,sg
-    - dem_type:     Copernicus 30m Global DEM
-    - etad:         False
-    - etad_dir:     None
-    - gdal_threads: 4
-    - log_dir:      LOG
-    - measurement:  gamma
-    - nrb_dir:      NRB
-    - rtc_dir:      RTC
-    - tmp_dir:      TMP
-    - wbm_dir:      WBM
+    - dem_type:          Copernicus 30m Global DEM
+    - etad:              False
+    - etad_dir:          None
+    - gdal_threads:      4
+    - log_dir:           LOG
+    - measurement:       gamma
+    - nrb_dir:           NRB
+    - rtc_dir:           RTC
+    - tmp_dir:           TMP
+    - wbm_dir:           WBM
+    (metadata section)
+    - access_url:        None
+    - doi:               None
+    - licence:           None
+    - processing_center: None
     """
     import S1_NRB
     if version:

--- a/S1_NRB/config.py
+++ b/S1_NRB/config.py
@@ -44,18 +44,17 @@ def get_config(config_file, proc_section='PROCESSING', **kwargs):
     out_dict: dict
         Dictionary of the parsed config parameters.
     """
+    parser = configparser.ConfigParser(allow_no_value=True,
+                                       converters={'_annotation': _parse_annotation,
+                                                   '_datetime': _parse_datetime,
+                                                   '_tile_list': _parse_tile_list})
     if isinstance(config_file, str):
         if not os.path.isfile(config_file):
             raise FileNotFoundError("Config file {} does not exist.".format(config_file))
-        
-        parser = configparser.ConfigParser(allow_no_value=True,
-                                           converters={'_annotation': _parse_annotation,
-                                                       '_datetime': _parse_datetime,
-                                                       '_tile_list': _parse_tile_list})
         parser.read(config_file)
     elif config_file is None:
-        parser = {proc_section: {},
-                  'METADATA': {}}
+        parser.add_section(proc_section)
+        parser.add_section('METADATA')
     else:
         raise TypeError(f"'config_file' must be of type str or None, was {type(config_file)}")
     out_dict = {}

--- a/S1_NRB/config.py
+++ b/S1_NRB/config.py
@@ -29,7 +29,7 @@ def get_keys(section):
         raise RuntimeError(f"unknown section: {section}. Options: 'processing', 'metadata'.")
 
 
-def get_config(config_file, proc_section='PROCESSING'):
+def get_config(config_file, proc_section='PROCESSING', **kwargs):
     """Returns the content of a `config.ini` file as a dictionary.
     
     Parameters
@@ -60,6 +60,10 @@ def get_config(config_file, proc_section='PROCESSING'):
         proc_sec = parser[proc_section]
     except KeyError:
         raise KeyError("Section '{}' does not exist in config file {}".format(proc_section, config_file))
+    
+    # override config file parameters
+    for k, v in kwargs.items():
+        proc_sec[k] = v
     
     for k, v in proc_sec.items():
         v = _keyval_check(key=k, val=v, allowed_keys=allowed_keys)

--- a/S1_NRB/config.py
+++ b/S1_NRB/config.py
@@ -44,14 +44,20 @@ def get_config(config_file, proc_section='PROCESSING', **kwargs):
     out_dict: dict
         Dictionary of the parsed config parameters.
     """
-    if not os.path.isfile(config_file):
-        raise FileNotFoundError("Config file {} does not exist.".format(config_file))
-    
-    parser = configparser.ConfigParser(allow_no_value=True,
-                                       converters={'_annotation': _parse_annotation,
-                                                   '_datetime': _parse_datetime,
-                                                   '_tile_list': _parse_tile_list})
-    parser.read(config_file)
+    if isinstance(config_file, str):
+        if not os.path.isfile(config_file):
+            raise FileNotFoundError("Config file {} does not exist.".format(config_file))
+        
+        parser = configparser.ConfigParser(allow_no_value=True,
+                                           converters={'_annotation': _parse_annotation,
+                                                       '_datetime': _parse_datetime,
+                                                       '_tile_list': _parse_tile_list})
+        parser.read(config_file)
+    elif config_file is None:
+        parser = {proc_section: {},
+                  'METADATA': {}}
+    else:
+        raise TypeError(f"'config_file' must be of type str or None, was {type(config_file)}")
     out_dict = {}
     
     # PROCESSING section

--- a/S1_NRB/config.py
+++ b/S1_NRB/config.py
@@ -133,9 +133,7 @@ def get_config(config_file, proc_section='PROCESSING', **kwargs):
             out_dict['annotation'] = ['dm', 'ei', 'id', 'lc', 'li', 'np', 'gs']
         else:
             out_dict['annotation'] = ['dm', 'ei', 'id', 'lc', 'li', 'np', 'sg']
-    
-    assert any([out_dict[k] is not None for k in ['aoi_tiles', 'aoi_geometry']])
-    
+        
     # METADATA section
     meta_keys = get_keys(section='metadata')
     try:

--- a/S1_NRB/config.py
+++ b/S1_NRB/config.py
@@ -4,6 +4,31 @@ from datetime import datetime
 from osgeo import gdal
 
 
+def get_keys(section):
+    """
+    get all allowed configuration keys
+    
+    Parameters
+    ----------
+    section: {'processing', 'metadata'}
+        the configuration section to get the allowed keys for.
+
+    Returns
+    -------
+    list[str]
+        a list of keys
+    """
+    if section == 'processing':
+        return ['mode', 'aoi_tiles', 'aoi_geometry', 'mindate', 'maxdate', 'acq_mode',
+                'work_dir', 'scene_dir', 'rtc_dir', 'tmp_dir', 'wbm_dir', 'measurement',
+                'db_file', 'kml_file', 'dem_type', 'gdal_threads', 'log_dir', 'nrb_dir',
+                'etad', 'etad_dir', 'product', 'annotation']
+    elif section == 'metadata':
+        return ['access_url', 'licence', 'doi', 'processing_center']
+    else:
+        raise RuntimeError(f"unknown section: {section}. Options: 'processing', 'metadata'.")
+
+
 def get_config(config_file, proc_section='PROCESSING'):
     """Returns the content of a `config.ini` file as a dictionary.
     
@@ -22,17 +47,15 @@ def get_config(config_file, proc_section='PROCESSING'):
     if not os.path.isfile(config_file):
         raise FileNotFoundError("Config file {} does not exist.".format(config_file))
     
-    parser = configparser.ConfigParser(allow_no_value=True, converters={'_annotation': _parse_annotation,
-                                                                        '_datetime': _parse_datetime,
-                                                                        '_tile_list': _parse_tile_list})
+    parser = configparser.ConfigParser(allow_no_value=True,
+                                       converters={'_annotation': _parse_annotation,
+                                                   '_datetime': _parse_datetime,
+                                                   '_tile_list': _parse_tile_list})
     parser.read(config_file)
     out_dict = {}
     
     # PROCESSING section
-    allowed_keys = ['mode', 'aoi_tiles', 'aoi_geometry', 'mindate', 'maxdate', 'acq_mode',
-                    'work_dir', 'scene_dir', 'rtc_dir', 'tmp_dir', 'wbm_dir', 'measurement',
-                    'db_file', 'kml_file', 'dem_type', 'gdal_threads', 'log_dir', 'nrb_dir',
-                    'etad', 'etad_dir', 'product', 'annotation']
+    allowed_keys = get_keys(section='processing')
     try:
         proc_sec = parser[proc_section]
     except KeyError:
@@ -110,7 +133,7 @@ def get_config(config_file, proc_section='PROCESSING'):
     assert any([out_dict[k] is not None for k in ['aoi_tiles', 'aoi_geometry']])
     
     # METADATA section
-    meta_keys = ['access_url', 'licence', 'doi', 'processing_center']
+    meta_keys = get_keys(section='metadata')
     try:
         meta_sec = parser['METADATA']
         out_dict['meta'] = {}

--- a/S1_NRB/config.py
+++ b/S1_NRB/config.py
@@ -163,16 +163,17 @@ def get_config(config_file, proc_section='PROCESSING', **kwargs):
     
     # METADATA section
     meta_keys = get_keys(section='metadata')
-    try:
-        meta_sec = parser['METADATA']
-        out_dict['meta'] = {}
-        for k, v in meta_sec.items():
-            v = _keyval_check(key=k, val=v, allowed_keys=meta_keys)
-            # No need to check values. Only requirement is that they're strings, which is configparser's default.
-            out_dict['meta'][k] = v
-    except KeyError:
-        # Use None for all relevant fields if the metadata section doesn't exist.
-        out_dict['meta'] = dict([(k, None) for k in meta_keys])
+    if 'METADATA' not in parser.keys():
+        parser.add_section('METADATA')
+    meta_sec = parser['METADATA']
+    out_dict['meta'] = {}
+    for k, v in meta_sec.items():
+        v = _keyval_check(key=k, val=v, allowed_keys=meta_keys)
+        # No need to check values. Only requirement is that they're strings, which is configparser's default.
+        out_dict['meta'][k] = v
+    for key in meta_keys:
+        if key not in out_dict['meta'].keys():
+            out_dict['meta'][key] = None
     
     return out_dict
 

--- a/S1_NRB/processor.py
+++ b/S1_NRB/processor.py
@@ -13,7 +13,7 @@ from datetime import datetime, timedelta
 gdal.UseExceptions()
 
 
-def main(config_file, section_name='PROCESSING', debug=False):
+def main(config_file, section_name='PROCESSING', debug=False, **kwargs):
     """
     Main function that initiates and controls the processing workflow.
     
@@ -26,9 +26,11 @@ def main(config_file, section_name='PROCESSING', debug=False):
         should be parsed from. Default is 'PROCESSING'.
     debug: bool
         Set pyroSAR logging level to DEBUG? Default is False.
+    **kwargs
+        extra arguments to override parameters in the config file. E.g. `acq_mode`.
     """
     update = False  # update existing products? Internal development flag.
-    config = get_config(config_file=config_file, proc_section=section_name)
+    config = get_config(config_file=config_file, proc_section=section_name, **kwargs)
     logger = anc.set_logging(config=config, debug=debug)
     geocode_prms = snap_conf(config=config)
     gdal_prms = gdal_conf(config=config)

--- a/docs/examples/nrb_cube.ipynb
+++ b/docs/examples/nrb_cube.ipynb
@@ -122,7 +122,7 @@
     "\n",
     "The term _lazy_ describes a [method of execution](https://tutorial.dask.org/01x_lazy.html) that only computes results when actually needed and thereby enables computations on larger-than-memory datasets. _[xarray](https://xarray.pydata.org/en/stable/index.html)_ is a Python library for working with labeled multi-dimensional arrays of data, while the Python library _[dask](https://docs.dask.org/en/latest/)_ facilitates parallel computing in a flexible way.\n",
     "\n",
-    "Compatibility with [odc-stac](https://github.com/opendatacube/odc-stac), a very [similar library](https://github.com/opendatacube/odc-stac/issues/54) to stackstac, will be tested in the near future."
+    "Compatibility with [odc-stac](https://github.com/opendatacube/odc-stac), a very [similar library](https://github.com/opendatacube/odc-stac/issues/54) to stackstac, has also been implemented."
    ]
   },
   {
@@ -1014,11 +1014,7 @@
   {
    "cell_type": "markdown",
    "id": "25b1a9eb-f4b9-49c5-ac0c-645d08cab3f4",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "As you can see in the output above, the collection of S1-NRB scenes was successfully loaded as an `xarray.DataArray`. The metadata attributes included in all STAC Items are now available as coordinate arrays (see [here](https://docs.xarray.dev/en/stable/user-guide/terminology.html#term-Coordinate) for clarification of Xarray's terminology) and can be utilized during analysis.\n",
     "\n",

--- a/docs/general/usage.rst
+++ b/docs/general/usage.rst
@@ -145,28 +145,34 @@ Command Line Interface
 Once a configuration file has been created and all of its parameters have been properly defined, it can be used to start
 the processor using the command line interface (CLI) tool provided with the S1_NRB package.
 
-The following options are currently available:
+The following options are currently available.
+
+Print a help message for the CLI tool:
 
 ::
 
     s1_nrb --help
 
-Print a help message for the CLI tool.
+Print the processor version:
 
 ::
 
     s1_nrb --version
 
-Print the processor version.
+Start the processor using parameters defined in the default section of a ``config.ini`` file:
 
 ::
 
     s1_nrb -c /path/to/config.ini
 
-Start the processor using parameters defined in the default section of a ``config.ini`` file.
+Start the processor using parameters defined in section ``SECTION_NAME`` of a ``config.ini`` file:
 
 ::
 
     s1_nrb -c /path/to/config.ini -s SECTION_NAME
 
-Start the processor using parameters defined in section ``SECTION_NAME`` of a ``config.ini`` file.
+Start the processor using parameters defined in the default section of a ``config.ini`` file but override parameters ``acq_mode`` and ``annotation``:
+
+::
+
+    s1_nrb -c /path/to/config.ini --acq_mode IW --annotation dm,id

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -20,3 +20,4 @@ dependencies:
   - nbsphinx
   - sphinx_rtd_theme
   - sphinx-toolbox
+  - ipython # for notebook code highlighting

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python>=3.8
   - gdal>=3.5.0
-  - click
+  - click>=7.1.0
   - lxml
   - pip
   - pystac

--- a/environment.yaml
+++ b/environment.yaml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python>=3.8
   - gdal>=3.5.0
-  - click
+  - click>=7.1.0
   - lxml
   - pip
   - pystac

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     packages=find_namespace_packages(where='.'),
     include_package_data=True,
     install_requires=['gdal>=3.5.0',
-                      'click',
+                      'click>=7.1.0',
                       'lxml',
                       'pystac',
                       'pyroSAR>=0.20.0',

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
                       's1etad>=0.5.3',
                       's1etad_tools>=0.8.1'],
     extras_require={
-          'docs': ['sphinx', 'sphinxcontrib-bibtex', 'nbsphinx', 'sphinx_rtd_theme', 'sphinx-toolbox'],
+          'docs': ['sphinx', 'sphinxcontrib-bibtex', 'nbsphinx', 'sphinx_rtd_theme', 'sphinx-toolbox', 'ipython'],
     },
     python_requires='>=3.8',
     license='MIT',


### PR DESCRIPTION
The processor can now be configured via the command line. Full configuration without a config file as well as partial configuration to override only some config file parameters are possible.
In the example, all parameters except `acq_mode` and `annotation` are read from the config file.
```bash
s1_nrb -c config.ini --acq_mode IW --annotation dm,id
```