### PR TITLE
enhanced time filtering

### DIFF
--- a/S1_NRB/cli.py
+++ b/S1_NRB/cli.py
@@ -32,6 +32,7 @@ def cli(ctx, config_file, section, debug, version):
     - annotation (measurement=gamma): dm,ei,id,lc,li,np,gs
     - annotation (measurement=sigma): dm,ei,id,lc,li,np,sg
     - dem_type:          Copernicus 30m Global DEM
+    - date_strict:       True
     - etad:              False
     - etad_dir:          None
     - gdal_threads:      4

--- a/S1_NRB/config.py
+++ b/S1_NRB/config.py
@@ -1,4 +1,6 @@
 import os
+import re
+from datetime import timedelta
 import configparser
 import dateutil.parser
 from osgeo import gdal
@@ -116,8 +118,13 @@ def get_config(config_file, proc_section='PROCESSING', **kwargs):
         if k == 'aoi_geometry':
             if v is not None:
                 assert os.path.isfile(v), "Parameter '{}': File {} could not be found".format(k, v)
-        if k.endswith('date'):
+        if k == 'mindate':
             v = proc_sec.get_datetime(k)
+        if k == 'maxdate':
+            date_short = re.search('^[0-9-]{10}$', v) is not None
+            v = proc_sec.get_datetime(k)
+            if date_short:
+                v += timedelta(days=1, microseconds=-1)
         if k == 'sensor':
             assert v in ['S1A', 'S1B']
         if k == 'acq_mode':
@@ -238,6 +245,7 @@ def _parse_list(s):
         return None
     else:
         return s.replace(' ', '').split(',')
+
 
 def _keyval_check(key, val, allowed_keys):
     """Helper function to check and clean up key,value pairs while parsing a config file."""

--- a/S1_NRB/config.py
+++ b/S1_NRB/config.py
@@ -25,7 +25,7 @@ def get_keys(section):
                 'work_dir', 'scene_dir', 'rtc_dir', 'tmp_dir', 'wbm_dir', 'measurement',
                 'db_file', 'kml_file', 'dem_type', 'gdal_threads', 'log_dir', 'nrb_dir',
                 'etad', 'etad_dir', 'product', 'annotation', 'stac_catalog', 'stac_collections',
-                'sensor']
+                'sensor', 'date_strict']
     elif section == 'metadata':
         return ['access_url', 'licence', 'doi', 'processing_center']
     else:
@@ -85,8 +85,10 @@ def get_config(config_file, proc_section='PROCESSING', **kwargs):
         proc_sec['gdal_threads'] = '4'
     if 'dem_type' not in proc_sec.keys():
         proc_sec['dem_type'] = 'Copernicus 30m Global DEM'
-    
-    # use previous defaults for measurement and annotation if they have not been defined
+    if 'date_strict' not in proc_sec.keys():
+        proc_sec['date_strict'] = 'True'
+        
+        # use previous defaults for measurement and annotation if they have not been defined
     if 'measurement' not in proc_sec.keys():
         proc_sec['measurement'] = 'gamma'
     if 'annotation' not in proc_sec.keys():
@@ -158,14 +160,11 @@ def get_config(config_file, proc_section='PROCESSING', **kwargs):
             allowed = ['Copernicus 10m EEA DEM', 'Copernicus 30m Global DEM II',
                        'Copernicus 30m Global DEM', 'GETASSE30']
             assert v in allowed, "Parameter '{}': expected to be one of {}; got '{}' instead".format(k, allowed, v)
-        if k == 'etad':
-            if v.lower() == 'true':
-                v = True
-            elif v.lower() == 'false':
-                v = False
-            else:
-                allowed = ['True', 'true', 'False', 'false']
-                raise ValueError("Parameter '{}': expected to be one of {}; got '{}' instead".format(k, allowed, v))
+        if k in ['etad', 'date_strict']:
+            try:
+                v = proc_sec.getboolean(k)
+            except ValueError:
+                raise RuntimeError(f"cannot parse boolean parameter '{k}' with value '{v}'")
         if k == 'product':
             allowed = ['GRD', 'SLC']
             assert v in allowed, "Parameter '{}': expected to be one of {}; got '{}' instead".format(k, allowed, v)

--- a/S1_NRB/processor.py
+++ b/S1_NRB/processor.py
@@ -83,7 +83,8 @@ def main(config_file, section_name='PROCESSING', debug=False, **kwargs):
                            product=config['product'],
                            acquisition_mode=acq_mode_search,
                            mindate=config['mindate'],
-                           maxdate=config['maxdate']))
+                           maxdate=config['maxdate'],
+                           date_strict=config['date_strict']))
     selection = list(set(selection))
     del vec
     

--- a/config.ini
+++ b/config.ini
@@ -26,6 +26,12 @@ aoi_geometry = None
 mindate = 2021-06-01
 maxdate = 2021-09-01
 
+# treat dates as strict limits or also allow flexible limits to incorporate scenes
+# whose acquisition period overlaps with the defined limit?
+# - strict: start >= mindate & stop <= maxdate
+# - not strict: stop >= mindate & start <= maxdate
+date_strict = True
+
 # OPTIONS: S1A, S1B
 sensor = S1A
 

--- a/config.ini
+++ b/config.ini
@@ -22,6 +22,7 @@ aoi_geometry = None
 
 # Allowed date formats: anything that can be parsed by
 # https://dateutil.readthedocs.io/en/stable/parser.html#dateutil.parser.parse
+# maxdate: format %Y-%m-%d will be interpreted as end of day, e.g. 2021-09-01 -> 2021-09-01 23:59:59.999999
 mindate = 2021-06-01
 maxdate = 2021-09-01
 

--- a/docs/general/usage.rst
+++ b/docs/general/usage.rst
@@ -34,6 +34,13 @@ If neither is defined, all tiles overlapping with the scene search result are pr
 The time period to create S1-NRB products for.
 Allowed are all string representations that can be parsed by :meth:`dateutil.parser.parse`.
 
+- **date_strict**
+Treat dates as strict limits or also allow flexible limits to incorporate scenes
+whose acquisition period overlaps with the defined limit?
+
+ + strict: start >= mindate & stop <= maxdate
+ + not strict: stop >= mindate & start <= maxdate
+
 - **sensor**
 
 Options: ``S1A | S1B``
@@ -184,7 +191,8 @@ Start the processor using parameters defined in section ``SECTION_NAME`` of a ``
 
     s1_nrb -c /path/to/config.ini -s SECTION_NAME
 
-Start the processor using parameters defined in the default section of a ``config.ini`` file but override parameters ``acq_mode`` and ``annotation``:
+Start the processor using parameters defined in the default section of a ``config.ini`` file but
+override some parameters, e.g. ``acq_mode`` and ``annotation``:
 
 ::
 


### PR DESCRIPTION
This extend the functionality of the acquisition time search and filtering:
- parameter `maxdate` in format `%Y-%M-%d` is now interpreted as end of day, e.g. `2021-09-01` -> `2021-09-01 23:59:59.999999`; other formats remain unaffected
- a new parameter `date_strict` can be used for better controlling the time filtering behavior
  * strict: start >= mindate & stop <= maxdate
  * not strict: stop >= mindate & start <= maxdate