### PR TITLE
general processor improvements

### DIFF
--- a/S1_NRB/ancillary.py
+++ b/S1_NRB/ancillary.py
@@ -318,6 +318,7 @@ def _log_process_config(logger, config):
     db_file             {config['db_file']}
     kml_file            {config['kml_file']}
     gdal_threads        {config.get('gdal_threads')}
+    snap_gpt_args       {config['snap_gpt_args']}
     
     ====================================================================================================================
     SOFTWARE

--- a/S1_NRB/cli.py
+++ b/S1_NRB/cli.py
@@ -26,6 +26,10 @@ def cli(ctx, config_file, section, debug, version):
     
     s1_nrb -c config.ini --acq_mode IW --annotation dm,id
     
+    The snap_gpt_args argument can be provided by using a dedicated argument separator and quotes:
+    
+    s1_nrb -c config.ini -- --snap_gpt_args "-J-Xmx100G -c 75G -q 30"
+    
     \b
     The following defaults are set:
     (processing section)
@@ -35,6 +39,7 @@ def cli(ctx, config_file, section, debug, version):
     - etad:              False
     - etad_dir:          None
     - gdal_threads:      4
+    - snap_gpt_args:     None
     - log_dir:           LOG
     - measurement:       gamma
     - nrb_dir:           NRB

--- a/S1_NRB/config.py
+++ b/S1_NRB/config.py
@@ -287,8 +287,8 @@ def snap_conf(config):
             'allow_res_osv': True,
             'dem_resampling_method': 'BILINEAR_INTERPOLATION',
             'img_resampling_method': 'BILINEAR_INTERPOLATION',
-            'slc_clean_edges': True,
-            'slc_clean_edges_pixels': 4,
+            'clean_edges': True,
+            'clean_edges_pixels': 4,
             'cleanup': True
             }
 

--- a/S1_NRB/dem.py
+++ b/S1_NRB/dem.py
@@ -302,7 +302,7 @@ def mosaic(geometry, dem_type, outname, epsg=None, kml_file=None,
             dem_autoload([geometry], demType=dem_type,
                          vrt=vrt, buffer=buffer, product='dem',
                          username=username, password=password)
-            dem_create(src=vrt, dst=outname, pbar=True,
+            dem_create(src=vrt, dst=outname, pbar=False,
                        geoid_convert=geoid_convert, geoid=geoid,
                        threads=threads, nodata=-32767)
 

--- a/S1_NRB/metadata/extract.py
+++ b/S1_NRB/metadata/extract.py
@@ -279,7 +279,7 @@ def calc_performance_estimates(files):
     """
     out = {}
     for f in files:
-        pol = re.search('[vh]{2}', f).group().upper()
+        pol = re.search('np-([vh]{2})', f).group(1).upper()
         with Raster(f) as ras:
             arr = ras.array()
             # The following need to be of type float, not numpy.float32 in order to be JSON serializable

--- a/S1_NRB/metadata/extract.py
+++ b/S1_NRB/metadata/extract.py
@@ -428,6 +428,10 @@ def calc_geolocation_accuracy(swath_identifier, ei_tif, dem_type, etad):
         stats = ras.allstats(approximate=False)
         ei_min = stats[0]['min']
     
+    if ei_min == 0:
+        raise RuntimeError(f'minimum ellipsoid incidence angle cannot be 0\n'
+                           f'(file: {ei_tif})')
+    
     # Remove generated '.aux.xml' file
     aux = finder(os.path.dirname(ei_tif), ['.tif.aux.xml$'], regex=True, recursive=False)
     for file in aux:

--- a/S1_NRB/processor.py
+++ b/S1_NRB/processor.py
@@ -205,6 +205,7 @@ def main(config_file, section_name='PROCESSING', debug=False, **kwargs):
                              tmpdir=config['tmp_dir'], kml=config['kml_file'],
                              dem=fname_dem, neighbors=neighbors,
                              export_extra=export_extra,
+                             gpt_args=config['snap_gpt_args'],
                              rlks=rlks, azlks=azlks, **geocode_prms)
                 t = round((time.time() - start_time), 2)
                 anc.log(handler=logger, mode='info', proc_step='RTC', scenes=scene.scene, msg=t)

--- a/S1_NRB/processor.py
+++ b/S1_NRB/processor.py
@@ -96,7 +96,7 @@ def main(config_file, section_name='PROCESSING', debug=False, **kwargs):
         raise RuntimeError(message.format(acq_mode=config['acq_mode'], product=config['product'],
                                           mindate=config['mindate'], maxdate=config['maxdate'],
                                           scene_dir=config['scene_dir']))
-    scenes = identify_many(selection)
+    scenes = identify_many(selection, sortkey='start')
     anc.check_acquisition_completeness(scenes=scenes, archive=archive)
     archive.close()
     
@@ -225,7 +225,7 @@ def main(config_file, section_name='PROCESSING', debug=False, **kwargs):
                         dem_type=config['dem_type'], kml_file=config['kml_file'],
                         tilenames=aoi_tiles, username=username, password=password,
                         dem_strict=True)
-        
+        print('preparing NRB products')
         selection_grouped = anc.group_by_time(scenes=scenes)
         for s, scenes in enumerate(selection_grouped):
             scenes_fnames = [x.scene for x in scenes]

--- a/S1_NRB/snap.py
+++ b/S1_NRB/snap.py
@@ -666,6 +666,7 @@ def process(scene, outdir, measurement, spacing, kml, dem,
     out_mli = tmp_base + '_mli.dim'
     out_mli_wf = out_mli.replace('.dim', '.xml')
     if not os.path.isfile(out_mli):
+        print('### multi-looking')
         mli(src=out_pre, dst=out_mli, workflow=out_mli_wf,
             spacing=spacing, rlks=rlks, azlks=azlks, gpt_args=gpt_args)
     if not os.path.isfile(out_mli):
@@ -680,6 +681,7 @@ def process(scene, outdir, measurement, spacing, kml, dem,
         out_rtc_wf = out_rtc.replace('.dim', '.xml')
         workflows.append(out_rtc_wf)
         if not os.path.isfile(out_rtc):
+            print('### radiometric terrain correction')
             rtc(src=out_mli, dst=out_rtc, workflow=out_rtc_wf, dem=dem,
                 dem_resampling_method=dem_resampling_method,
                 sigma0='gammaSigmaRatio' in export_extra,
@@ -749,7 +751,7 @@ def process(scene, outdir, measurement, spacing, kml, dem,
             group = list(group)
             geometries = [aoi_from_tile(kml=kml, tile=x) for x in group]
             epsg = geometries[0].getProjection(type='epsg')
-            print(f'### processing EPSG:{epsg}')
+            print(f'### geocoding to EPSG:{epsg}')
             ext = get_max_ext(geometries=geometries)
             align_x = ext['xmin']
             align_y = ext['ymax']
@@ -762,7 +764,7 @@ def process(scene, outdir, measurement, spacing, kml, dem,
         with id.bbox() as geom:
             ext = geom.extent
             epsg = utm_autodetect(geom, 'epsg')
-            print(f'### processing EPSG:{epsg}')
+            print(f'### geocoding to EPSG:{epsg}')
             tiles = tile_from_aoi(vector=geom, kml=kml, epsg=epsg,
                                   return_geometries=True)
             ext_utm = tiles[0].extent

--- a/S1_NRB/snap.py
+++ b/S1_NRB/snap.py
@@ -13,7 +13,7 @@ from S1_NRB.tile_extraction import tile_from_aoi, aoi_from_tile
 from S1_NRB.ancillary import get_max_ext
 
 
-def mli(src, dst, workflow, spacing=None, rlks=None, azlks=None):
+def mli(src, dst, workflow, spacing=None, rlks=None, azlks=None, gpt_args=None):
     """
     Multi-looking.
     
@@ -33,7 +33,11 @@ def mli(src, dst, workflow, spacing=None, rlks=None, azlks=None):
         the number of range looks.
     azlks: int or None
         the number of azimuth looks.
-
+    gpt_args: list[str] or None
+        a list of additional arguments to be passed to the gpt call
+        
+        - e.g. ``['-x', '-c', '2048M']`` for increased tile cache size and intermediate clearing
+    
     Returns
     -------
     
@@ -59,11 +63,12 @@ def mli(src, dst, workflow, spacing=None, rlks=None, azlks=None):
         write.parameters['formatName'] = 'BEAM-DIMAP'
         ############################################
         wf.write(workflow)
-        gpt(xmlfile=workflow, tmpdir=os.path.dirname(dst))
+        gpt(xmlfile=workflow, tmpdir=os.path.dirname(dst),
+            gpt_args=gpt_args)
 
 
 def pre(src, dst, workflow, allow_res_osv=True, osv_continue_on_fail=False,
-        output_noise=True, output_beta0=True):
+        output_noise=True, output_beta0=True, gpt_args=None):
     """
     General SAR preprocessing. The following operators are used (optional steps in brackets):
     Apply-Orbit-File(->Remove-GRD-Border-Noise)->Calibration->ThermalNoiseRemoval(->TOPSAR-Deburst)
@@ -84,7 +89,11 @@ def pre(src, dst, workflow, allow_res_osv=True, osv_continue_on_fail=False,
         output the noise power images?
     output_beta0: bool
         output beta nought backscatter needed for RTC?
-
+    gpt_args: list[str] or None
+        a list of additional arguments to be passed to the gpt call
+        
+        - e.g. ``['-x', '-c', '2048M']`` for increased tile cache size and intermediate clearing
+    
     Returns
     -------
 
@@ -135,10 +144,11 @@ def pre(src, dst, workflow, allow_res_osv=True, osv_continue_on_fail=False,
     write.parameters['formatName'] = 'BEAM-DIMAP'
     ############################################
     wf.write(workflow)
-    gpt(xmlfile=workflow, tmpdir=os.path.dirname(dst))
+    gpt(xmlfile=workflow, tmpdir=os.path.dirname(dst),
+        gpt_args=gpt_args)
 
 
-def grd_buffer(src, dst, workflow, neighbors, buffer=10):
+def grd_buffer(src, dst, workflow, neighbors, buffer=10, gpt_args=None):
     """
     GRD extent buffering.
     GRDs, unlike SLCs, do not overlap in azimuth.
@@ -158,7 +168,11 @@ def grd_buffer(src, dst, workflow, neighbors, buffer=10):
         the file names of neighboring scenes
     buffer: int
         the number of pixels to buffer
-
+    gpt_args: list[str] or None
+        a list of additional arguments to be passed to the gpt call
+        
+        - e.g. ``['-x', '-c', '2048M']`` for increased tile cache size and intermediate clearing
+     
     Returns
     -------
 
@@ -193,11 +207,13 @@ def grd_buffer(src, dst, workflow, neighbors, buffer=10):
     write.parameters['formatName'] = 'BEAM-DIMAP'
     ############################################
     wf.write(workflow)
-    gpt(xmlfile=workflow, tmpdir=os.path.dirname(dst))
+    gpt(xmlfile=workflow, tmpdir=os.path.dirname(dst),
+        gpt_args=gpt_args)
 
 
 def rtc(src, dst, workflow, dem, dem_resampling_method='BILINEAR_INTERPOLATION',
-        sigma0=True, scattering_area=True, dem_oversampling_multiple=2):
+        sigma0=True, scattering_area=True, dem_oversampling_multiple=2,
+        gpt_args=None):
     """
     Radiometric Terrain Flattening.
     
@@ -221,7 +237,11 @@ def rtc(src, dst, workflow, dem, dem_resampling_method='BILINEAR_INTERPOLATION',
         a factor to multiply the DEM oversampling factor computed by SNAP.
         The SNAP default of 1 has been found to be insufficient with stripe
         artifacts remaining in the image.
-
+    gpt_args: list[str] or None
+        a list of additional arguments to be passed to the gpt call
+        
+        - e.g. ``['-x', '-c', '2048M']`` for increased tile cache size and intermediate clearing
+    
     Returns
     -------
 
@@ -257,10 +277,11 @@ def rtc(src, dst, workflow, dem, dem_resampling_method='BILINEAR_INTERPOLATION',
     write.parameters['formatName'] = 'BEAM-DIMAP'
     ############################################
     wf.write(workflow)
-    gpt(xmlfile=workflow, tmpdir=os.path.dirname(dst))
+    gpt(xmlfile=workflow, tmpdir=os.path.dirname(dst),
+        gpt_args=gpt_args)
 
 
-def gsr(src, dst, workflow, src_sigma=None):
+def gsr(src, dst, workflow, src_sigma=None, gpt_args=None):
     """
     Gamma-sigma ratio computation for either ellipsoidal or RTC sigma nought.
     
@@ -274,7 +295,11 @@ def gsr(src, dst, workflow, src_sigma=None):
         the output SNAP XML workflow filename.
     src_sigma: str or None
         the optional file name of a second source product from which to read the sigma band.
-
+    gpt_args: list[str] or None
+        a list of additional arguments to be passed to the gpt call
+        
+        - e.g. ``['-x', '-c', '2048M']`` for increased tile cache size and intermediate clearing
+    
     Returns
     -------
 
@@ -317,10 +342,11 @@ def gsr(src, dst, workflow, src_sigma=None):
     write.parameters['formatName'] = 'BEAM-DIMAP'
     ############################################
     wf.write(workflow)
-    gpt(xmlfile=workflow, tmpdir=os.path.dirname(dst))
+    gpt(xmlfile=workflow, tmpdir=os.path.dirname(dst),
+        gpt_args=gpt_args)
 
 
-def sgr(src, dst, workflow, src_gamma=None):
+def sgr(src, dst, workflow, src_gamma=None, gpt_args=None):
     """
     Sigma-gamma ratio computation.
 
@@ -334,7 +360,11 @@ def sgr(src, dst, workflow, src_gamma=None):
         the output SNAP XML workflow filename.
     src_gamma: str or None
         the optional file name of a second source product from which to read the gamma band.
-
+    gpt_args: list[str] or None
+        a list of additional arguments to be passed to the gpt call
+        
+        - e.g. ``['-x', '-c', '2048M']`` for increased tile cache size and intermediate clearing
+    
     Returns
     -------
 
@@ -377,13 +407,14 @@ def sgr(src, dst, workflow, src_gamma=None):
     write.parameters['formatName'] = 'BEAM-DIMAP'
     ############################################
     wf.write(workflow)
-    gpt(xmlfile=workflow, tmpdir=os.path.dirname(dst))
+    gpt(xmlfile=workflow, tmpdir=os.path.dirname(dst),
+        gpt_args=gpt_args)
 
 
 def geo(*src, dst, workflow, spacing, crs, geometry=None, buffer=0.01,
         export_extra=None, standard_grid_origin_x=0, standard_grid_origin_y=0,
         dem, dem_resampling_method='BILINEAR_INTERPOLATION',
-        img_resampling_method='BILINEAR_INTERPOLATION', **bands):
+        img_resampling_method='BILINEAR_INTERPOLATION', gpt_args=None, **bands):
     """
     Range-Doppler geocoding.
     
@@ -421,6 +452,10 @@ def geo(*src, dst, workflow, spacing, crs, geometry=None, buffer=0.01,
         the DEM resampling method
     img_resampling_method: str
         the SAR image resampling method
+    gpt_args: list[str] or None
+        a list of additional arguments to be passed to the gpt call
+        
+        - e.g. ``['-x', '-c', '2048M']`` for increased tile cache size and intermediate clearing
     bands
         band ids for the input scenes in `src` as lists with keys bands<index>,
         e.g., ``bands1=['NESZ_VV'], bands2=['Gamma0_VV'], ...``
@@ -476,7 +511,8 @@ def geo(*src, dst, workflow, spacing, crs, geometry=None, buffer=0.01,
     write.parameters['formatName'] = 'BEAM-DIMAP'
     ############################################
     wf.write(workflow)
-    gpt(xmlfile=workflow, tmpdir=os.path.dirname(dst))
+    gpt(xmlfile=workflow, tmpdir=os.path.dirname(dst),
+        gpt_args=gpt_args)
 
 
 def process(scene, outdir, measurement, spacing, kml, dem,
@@ -484,7 +520,7 @@ def process(scene, outdir, measurement, spacing, kml, dem,
             img_resampling_method='BILINEAR_INTERPOLATION',
             rlks=None, azlks=None, tmpdir=None, export_extra=None,
             allow_res_osv=True, slc_clean_edges=True, slc_clean_edges_pixels=4,
-            neighbors=None, cleanup=True):
+            neighbors=None, gpt_args=None, cleanup=True):
     """
     Main function for SAR processing with SNAP.
     
@@ -540,6 +576,10 @@ def process(scene, outdir, measurement, spacing, kml, dem,
         a buffer around the main scene using function :func:`grd_buffer`.
         If GRDs are processed compeletely independently, gaps are introduced
         due to a missing overlap between GRDs.
+    gpt_args: list[str] or None
+        a list of additional arguments to be passed to the gpt call
+        
+        - e.g. ``['-x', '-c', '2048M']`` for increased tile cache size and intermediate clearing
     cleanup: bool
         Delete intermediate files after successful process termination?
 
@@ -591,7 +631,7 @@ def process(scene, outdir, measurement, spacing, kml, dem,
     if not os.path.isfile(out_pre):
         pre(src=scene, dst=out_pre, workflow=out_pre_wf,
             allow_res_osv=allow_res_osv, output_noise=output_noise,
-            output_beta0=apply_rtc)
+            output_beta0=apply_rtc, gpt_args=gpt_args)
     ############################################################################
     # GRD buffering
     if neighbors is not None:
@@ -608,7 +648,7 @@ def process(scene, outdir, measurement, spacing, kml, dem,
                 print('### preprocessing neighbor:', item)
                 pre(src=item, dst=out_pre_nb, workflow=out_pre_nb_wf,
                     allow_res_osv=allow_res_osv, output_noise=output_noise,
-                    output_beta0=apply_rtc)
+                    output_beta0=apply_rtc, gpt_args=gpt_args)
             out_pre_neighbors.append(out_pre_nb)
         ########################################################################
         # buffering
@@ -618,7 +658,7 @@ def process(scene, outdir, measurement, spacing, kml, dem,
         if not os.path.isfile(out_buffer):
             print('### buffering scene with neighboring acquisitions')
             grd_buffer(src=out_pre, dst=out_buffer, workflow=out_buffer_wf,
-                       neighbors=out_pre_neighbors)
+                       neighbors=out_pre_neighbors, gpt_args=gpt_args)
         out_pre = out_buffer
     ############################################################################
     # multi-looking
@@ -626,7 +666,7 @@ def process(scene, outdir, measurement, spacing, kml, dem,
     out_mli_wf = out_mli.replace('.dim', '.xml')
     if not os.path.isfile(out_mli):
         mli(src=out_pre, dst=out_mli, workflow=out_mli_wf,
-            spacing=spacing, rlks=rlks, azlks=azlks)
+            spacing=spacing, rlks=rlks, azlks=azlks, gpt_args=gpt_args)
     if not os.path.isfile(out_mli):
         out_mli = out_pre
     else:
@@ -642,7 +682,8 @@ def process(scene, outdir, measurement, spacing, kml, dem,
             rtc(src=out_mli, dst=out_rtc, workflow=out_rtc_wf, dem=dem,
                 dem_resampling_method=dem_resampling_method,
                 sigma0='gammaSigmaRatio' in export_extra,
-                scattering_area='scatteringArea' in export_extra)
+                scattering_area='scatteringArea' in export_extra,
+                gpt_args=gpt_args)
         ########################################################################
         # gamma-sigma ratio computation
         out_gsr = None
@@ -651,7 +692,8 @@ def process(scene, outdir, measurement, spacing, kml, dem,
             out_gsr_wf = out_gsr.replace('.dim', '.xml')
             workflows.append(out_gsr_wf)
             if not os.path.isfile(out_gsr):
-                gsr(src=out_rtc, dst=out_gsr, workflow=out_gsr_wf)
+                gsr(src=out_rtc, dst=out_gsr, workflow=out_gsr_wf,
+                    gpt_args=gpt_args)
         ########################################################################
         # sigma-gamma ratio computation
         out_sgr = None
@@ -661,7 +703,7 @@ def process(scene, outdir, measurement, spacing, kml, dem,
             workflows.append(out_sgr_wf)
             if not os.path.isfile(out_sgr):
                 sgr(src=out_mli, dst=out_sgr, workflow=out_sgr_wf,
-                    src_gamma=out_rtc)
+                    src_gamma=out_rtc, gpt_args=gpt_args)
     ############################################################################
     # geocoding
     with id.geometry() as geom:
@@ -699,7 +741,8 @@ def process(scene, outdir, measurement, spacing, kml, dem,
                 standard_grid_origin_y=align_y,
                 bands0=bands0, bands1=bands1, dem=dem,
                 dem_resampling_method=dem_resampling_method,
-                img_resampling_method=img_resampling_method)
+                img_resampling_method=img_resampling_method,
+                gpt_args=gpt_args)
             postprocess(out_geo, slc_clean_edges=slc_clean_edges,
                         slc_clean_edges_pixels=slc_clean_edges_pixels)
         for wf in workflows:

--- a/S1_NRB/snap.py
+++ b/S1_NRB/snap.py
@@ -527,7 +527,7 @@ def process(scene, outdir, measurement, spacing, kml, dem,
             dem_resampling_method='BILINEAR_INTERPOLATION',
             img_resampling_method='BILINEAR_INTERPOLATION',
             rlks=None, azlks=None, tmpdir=None, export_extra=None,
-            allow_res_osv=True, slc_clean_edges=True, slc_clean_edges_pixels=4,
+            allow_res_osv=True, clean_edges=True, clean_edges_pixels=4,
             neighbors=None, gpt_args=None, cleanup=True):
     """
     Main function for SAR processing with SNAP.
@@ -574,10 +574,10 @@ def process(scene, outdir, measurement, spacing, kml, dem,
          - scatteringArea
     allow_res_osv: bool
         Also allow the less accurate RES orbit files to be used?
-    slc_clean_edges: bool
+    clean_edges: bool
         Erode noisy image edges? See :func:`pyroSAR.snap.auxil.erode_edges`.
         Does not apply to layover-shadow mask.
-    slc_clean_edges_pixels: int
+    clean_edges_pixels: int
         The number of pixels to erode.
     neighbors: list[str] or None
         (only applies to GRD) an optional list of neighboring scenes to add
@@ -745,8 +745,8 @@ def process(scene, outdir, measurement, spacing, kml, dem,
                 dem_resampling_method=dem_resampling_method,
                 img_resampling_method=img_resampling_method,
                 gpt_args=gpt_args)
-            postprocess(out_geo, slc_clean_edges=slc_clean_edges,
-                        slc_clean_edges_pixels=slc_clean_edges_pixels)
+            postprocess(out_geo, clean_edges=clean_edges,
+                        clean_edges_pixels=clean_edges_pixels)
         for wf in workflows:
             wf_dst = os.path.join(outdir_scene, os.path.basename(wf))
             if wf != wf_dst:
@@ -797,25 +797,25 @@ def process(scene, outdir, measurement, spacing, kml, dem,
             shutil.rmtree(tmpdir_scene)
 
 
-def postprocess(src, slc_clean_edges=True, slc_clean_edges_pixels=4):
+def postprocess(src, clean_edges=True, clean_edges_pixels=4):
     """
-    Performs SLC edge cleaning and sets the nodata value in the output ENVI HDR files.
+    Performs edge cleaning and sets the nodata value in the output ENVI HDR files.
     
     Parameters
     ----------
     src: str
         the file name of the source scene. Format is BEAM-DIMAP.
-    slc_clean_edges: bool
-        perform SLC edge cleaning?
-    slc_clean_edges_pixels: int
+    clean_edges: bool
+        perform edge cleaning?
+    clean_edges_pixels: int
         the number of pixels to erode during edge cleaning.
 
     Returns
     -------
 
     """
-    if slc_clean_edges:
-        erode_edges(src=src, only_boundary=True, pixels=slc_clean_edges_pixels)
+    if clean_edges:
+        erode_edges(src=src, only_boundary=True, pixels=clean_edges_pixels)
     datadir = src.replace('.dim', '.data')
     hdrfiles = finder(target=datadir, matchlist=['*.hdr'])
     for hdrfile in hdrfiles:

--- a/config.ini
+++ b/config.ini
@@ -83,6 +83,11 @@ dem_type = Copernicus 30m Global DEM
 # Temporarily changes GDAL_NUM_THREADS during processing. Will be reset after processing has finished.
 gdal_threads = 4
 
+# Further arguments to be passed to the internal SNAP GPT call
+# e.g. run GPT with 100GB of memory, 75GB cache and 30 threads:
+# snap_gpt_args = -J-Xmx100G -c 75G -q 30
+snap_gpt_args =
+
 # The backscatter measurement convention. Either gamma nought RTC or ellipsoidal sigma nought.
 # Other conventions will be included in the product as VRTs using the annotation layers gs and sg.
 # OPTIONS: gamma | sigma

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -13,7 +13,7 @@ dependencies:
   - pystac
   - pystac-client
   - scipy
-  - pyroSAR>=0.20.0
+  - pyroSAR>=0.21.0
   - spatialist>=0.12.0
   - s1etad>=0.5.3
   - s1etad_tools>=0.8.1

--- a/environment.yaml
+++ b/environment.yaml
@@ -13,7 +13,7 @@ dependencies:
   - pystac
   - pystac-client
   - scipy
-  - pyroSAR>=0.20.0
+  - pyroSAR>=0.21.0
   - spatialist>=0.12.0
   - s1etad>=0.5.3
   - s1etad_tools>=0.8.1

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
                       'click>=7.1.0',
                       'lxml',
                       'pystac',
-                      'pyroSAR>=0.20.0',
+                      'pyroSAR>=0.21.0',
                       'spatialist>=0.12.0',
                       'scipy',
                       's1etad>=0.5.3',


### PR DESCRIPTION
This improves on the general processing workflow stability:
- [dem.mosaic] the progress bar has been removed, which otherwise clutters logfiles in batch jobs
- a new configuration parameter `snap_gpt_args` enables parametrization of the underlying SNAP GPT call; this has been found particularly relevant in an HPC environment where SNAP may try to use more resources than ordered in the SLURM job; all functions of the `S1_NRB.snap` have been extended with an argument `gpt_args` accordingly
- [snap.process](https://s1-nrb.readthedocs.io/en/latest/api.html#S1_NRB.snap.process): a new internal flag `utm_multi` enables processing to a single UTM zone if set to False; this is only intended for debugging and experimentation purposes
- preprocessed GRDs are no longer deleted so that they can be reused for buffering of neighboring scenes; a mechanism to delete these files once they are no longer needed is yet to be implemented (closes https://github.com/SAR-ARD/S1_NRB/issues/75, new issue: https://github.com/SAR-ARD/S1_NRB/issues/86)
- GRD buffering: the method has been improved to no longer buffer a fixed number of source pixels but rather a multiple of the target pixel spacing in meters; the former might be insufficient if the target spacing is lower than the source spacing, in particular in combination with the edge cleaning performed during [snap.postprocess](https://s1-nrb.readthedocs.io/en/latest/api.html#S1_NRB.snap.postprocess)

further bug fixes:
- [metadata.extract.calculate_geolocation_accuracy](https://s1-nrb.readthedocs.io/en/latest/api.html#S1_NRB.metadata.extract.calc_geolocation_accuracy): raise an additional error if the ellipsoidal incidence angle image only contains 0 (nodata)
- [nrb.get_datasets](https://s1-nrb.readthedocs.io/en/latest/api.html#S1_NRB.nrb.get_datasets): raise an error if no processing output could be found but just delete the scene from the list without raising an error if the files do not contain valid data
- [metadata.extract.calc_performance_estimates](https://s1-nrb.readthedocs.io/en/latest/api.html#S1_NRB.metadata.extract.calc_performance_estimates): fixed bug in noise power file name parsing
- [processor.main](https://s1-nrb.readthedocs.io/en/latest/api.html#S1_NRB.processor.main): if the scene footprints are used as geometry (`aoi_tiles` and `aoi_geometry` undefined), ensure full tile coverage at the ends of the data take groups