### PR TITLE
various bug fixes

### DIFF
--- a/S1_NRB/ancillary.py
+++ b/S1_NRB/ancillary.py
@@ -262,7 +262,7 @@ def group_by_time(scenes, time=3):
     for i in range(1, len(scenes)):
         start = datetime.strptime(scenes[i].start, '%Y%m%dT%H%M%S')
         stop_pred = datetime.strptime(scenes[i - 1].stop, '%Y%m%dT%H%M%S')
-        diff = (stop_pred - start).total_seconds()
+        diff = abs((stop_pred - start).total_seconds())
         if diff <= time:
             group.append(scenes[i])
         else:

--- a/S1_NRB/ancillary.py
+++ b/S1_NRB/ancillary.py
@@ -300,6 +300,7 @@ def _log_process_config(logger, config):
     aoi_geometry        {config['aoi_geometry']}
     mindate             {config['mindate'].isoformat()}
     maxdate             {config['maxdate'].isoformat()}
+    sensor              {config['sensor']}
     acq_mode            {config['acq_mode']}
     product             {config['product']}
     measurement         {config.get('measurement')}

--- a/S1_NRB/config.py
+++ b/S1_NRB/config.py
@@ -126,7 +126,7 @@ def get_config(config_file, proc_section='PROCESSING', **kwargs):
         if k == 'mindate':
             v = proc_sec.get_datetime(k)
         if k == 'maxdate':
-            date_short = re.search('^[0-9-]{10}$', v) is not None
+            date_short = re.search('^[0-9-]{10}$', v.strip()) is not None
             v = proc_sec.get_datetime(k)
             if date_short:
                 v += timedelta(days=1, microseconds=-1)

--- a/S1_NRB/processor.py
+++ b/S1_NRB/processor.py
@@ -113,15 +113,16 @@ def main(config_file, section_name='PROCESSING', debug=False, **kwargs):
     del vec
     
     if len(selection) == 0:
-        message = "No scenes could be found for the following search query:\n" \
-                  " sensor:    '{sensor}'\n" \
-                  " product:   '{product}'\n" \
-                  " acq. mode: '{acq_mode}'\n" \
-                  " mindate:   '{mindate}'\n" \
-                  " maxdate:   '{maxdate}'\n"
-        raise RuntimeError(message.format(acq_mode=config['acq_mode'], product=config['product'],
-                                          mindate=config['mindate'], maxdate=config['maxdate'],
-                                          scene_dir=config['scene_dir']))
+        msg = "No scenes could be found for the following search query:\n" \
+              " sensor:    '{sensor}'\n" \
+              " product:   '{product}'\n" \
+              " acq. mode: '{acq_mode}'\n" \
+              " mindate:   '{mindate}'\n" \
+              " maxdate:   '{maxdate}'\n"
+        print(msg.format(sensor=config['sensor'], acq_mode=config['acq_mode'],
+                         product=config['product'], mindate=config['mindate'],
+                         maxdate=config['maxdate'], scene_dir=config['scene_dir']))
+        return
     scenes = identify_many(selection, sortkey='start')
     anc.check_acquisition_completeness(scenes=scenes, archive=archive)
     archive.close()

--- a/S1_NRB/processor.py
+++ b/S1_NRB/processor.py
@@ -253,11 +253,11 @@ def main(config_file, section_name='PROCESSING', debug=False, **kwargs):
                         dem_strict=True)
         print('preparing NRB products')
         selection_grouped = anc.group_by_time(scenes=scenes)
-        for s, scenes in enumerate(selection_grouped):
+        for s, group in enumerate(selection_grouped):
             # check that the scenes can really be grouped together
-            anc.check_scene_consistency(scenes=scenes)
+            anc.check_scene_consistency(scenes=group)
             # get the geometries of all tiles that overlap with the current scene group
-            vec = [x.geometry() for x in scenes]
+            vec = [x.geometry() for x in group]
             tiles = tile_ex.tile_from_aoi(vector=vec,
                                           kml=config['kml_file'],
                                           return_geometries=True,
@@ -267,7 +267,7 @@ def main(config_file, section_name='PROCESSING', debug=False, **kwargs):
             s_total = len(selection_grouped)
             for t, tile in enumerate(tiles):
                 # select all scenes from the group whose footprint overlaps with the current tile
-                scenes_sub = [x for x in scenes if intersect(tile, x.geometry())]
+                scenes_sub = [x for x in group if intersect(tile, x.geometry())]
                 scenes_sub_fnames = [x.scene for x in scenes_sub]
                 outdir = os.path.join(config['nrb_dir'], tile.mgrs)
                 os.makedirs(outdir, exist_ok=True)

--- a/config.ini
+++ b/config.ini
@@ -32,7 +32,7 @@ maxdate = 2021-09-01
 # - not strict: stop >= mindate & start <= maxdate
 date_strict = True
 
-# OPTIONS: S1A, S1B
+# OPTIONS: S1A | S1B
 sensor = S1A
 
 # OPTIONS: IW | EW | SM

--- a/docs/about/changelog.rst
+++ b/docs/about/changelog.rst
@@ -60,7 +60,7 @@ Changelog
 1.0.0 | 2022-06-23
 ------------------
 
-* Dockerfile to build S1_NRB image (`#27 <https://github.com/SAR-ARD/S1_NRB/pull/31>`_)
+* Dockerfile to build S1_NRB image (`#31 <https://github.com/SAR-ARD/S1_NRB/pull/31>`_)
 * adjustments to nodata value (`#28 <https://github.com/SAR-ARD/S1_NRB/pull/28>`_)
 * renamed XML tag 'nrb' to 's1-nrb' (`#36 <https://github.com/SAR-ARD/S1_NRB/pull/36>`_)
 * Metadata & Config Improvements (`#30 <https://github.com/SAR-ARD/S1_NRB/pull/30>`_)

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -24,3 +24,4 @@ dependencies:
   - sphinx_rtd_theme
   - sphinx-toolbox
   - ipython # for notebook code highlighting
+  - filelock  # needed for sphinx_toolbox.collapse


### PR DESCRIPTION
- [get_config](https://s1-nrb.readthedocs.io/en/latest/api.html#S1_NRB.config.get_config): strip formatting characters like `\r` from date strings (`mindate`, `maxdate`), which were present when directly passing the arguments via a command line call in bash scripts (12c8e33)
- [group_by_time](https://s1-nrb.readthedocs.io/en/latest/api.html#S1_NRB.ancillary.group_by_time): compute the absolute acquisition time difference to decide whether two scenes go into the same group (a7a149a)
- [processor.main](https://s1-nrb.readthedocs.io/en/latest/api.html#S1_NRB.processor.main): do not reassign variable inside loop (c3d5bf9)
- [processor.main](https://s1-nrb.readthedocs.io/en/latest/api.html#S1_NRB.processor.main): do not raise an error when no scenes were found but just print a message and quit instead (8d30451)
- added the sensor to the log file configuration overview (b9e78ef)
- [STACArchive](https://s1-nrb.readthedocs.io/en/latest/api.html#S1_NRB.archive.STACArchive): retry opening and searching the catalog to address temporary unavailability or increased latency (a2e511e)
- [STACArchive.select](https://s1-nrb.readthedocs.io/en/latest/api.html#S1_NRB.archive.STACArchive.select): filter out duplicates (4d033d9)