### PR TITLE
Bug fix to allow `annotation = None`

### DIFF
--- a/S1_NRB/config.py
+++ b/S1_NRB/config.py
@@ -216,12 +216,13 @@ def _parse_annotation(s):
     """Custom converter for configparser:
     https://docs.python.org/3/library/configparser.html#customizing-parser-behaviour"""
     annotation_list = _parse_list(s)
-    allowed = ['dm', 'ei', 'em', 'id', 'lc', 'li', 'np', 'gs', 'sg']
-    for annotation in annotation_list:
-        if annotation not in allowed:
-            msg = "Parameter 'annotation': Error while parsing to list; " \
-                  "annotation '{}' is not supported. Allowed keys:\n{}"
-            raise ValueError(msg.format(annotation, allowed))
+    if annotation_list is not None:
+        allowed = ['dm', 'ei', 'em', 'id', 'lc', 'li', 'np', 'gs', 'sg']
+        for annotation in annotation_list:
+            if annotation not in allowed:
+                msg = "Parameter 'annotation': Error while parsing to list; " \
+                      "annotation '{}' is not supported. Allowed keys:\n{}"
+                raise ValueError(msg.format(annotation, allowed))
     return annotation_list
 
 

--- a/S1_NRB/nrb.py
+++ b/S1_NRB/nrb.py
@@ -119,7 +119,7 @@ def format(config, scenes, datadir, outdir, tile, extent, epsg, wbm=None,
             if c1 or c2 or c3:
                 allowed.append(key)
     else:
-        allowed = list(datasets[0].keys())
+        allowed = [key for key in datasets[0].keys() if re.search('[gs]-lin', key)]
         annotation = []
     for item in ['em', 'id']:
         if item in annotation:


### PR DESCRIPTION
Bug fixes to actually allow the following option:
```
# Use one of the following to create no annotation layer:
# annotation =
# annotation = None
```