### PR TITLE
Save original source metadata 

### DIFF
--- a/S1_NRB/metadata/extract.py
+++ b/S1_NRB/metadata/extract.py
@@ -1,5 +1,7 @@
 import os
 import re
+import shutil
+import zipfile
 import math
 import json
 from lxml import etree
@@ -750,3 +752,38 @@ def meta_dict(config, target, src_ids, rtc_dir, proc_time, start, stop, compress
         meta['source'][uid]['timeStop'] = datetime.strptime(src_sid[uid].stop, '%Y%m%dT%H%M%S')
     
     return meta
+
+
+def copy_src_meta(target, src_ids):
+    """
+    Copies the original metadata of the source scenes to the NRB product scene.
+    
+    Parameters
+    ----------
+    target: str
+        A path pointing to the NRB product scene being created.
+    src_ids: list[pyroSAR.drivers.ID]
+        List of :class:`~pyroSAR.drivers.ID` objects of all source scenes that overlap with the current MGRS tile.
+    
+    Returns
+    -------
+    None
+    """
+    source_dir = os.path.join(target, 'source')
+    for src_id in src_ids:
+        pid = re.match(src_id.pattern, os.path.basename(src_id.file)).group('productIdentifier')
+        
+        if src_id.scene.endswith('.zip'):
+            base = os.path.basename(src_id.file)
+            with zipfile.ZipFile(src_id.scene, "r") as zip_ref:
+                zip_ref.extract(member=os.path.join(base, 'manifest.safe'), path=source_dir)
+                annotation_files = [f for f in zip_ref.namelist() if os.path.join(base, 'annotation') in f]
+                zip_ref.extractall(members=annotation_files, path=source_dir)
+            os.rename(os.path.join(source_dir, base), os.path.join(source_dir, pid))
+        else:
+            source_dir = os.path.join(source_dir, pid)
+            os.makedirs(source_dir, exist_ok=True)
+            shutil.copy(src=os.path.join(src_id.scene, 'manifest.safe'),
+                        dst=os.path.join(source_dir, 'manifest.safe'))
+            shutil.copytree(src=os.path.join(src_id.scene, 'annotation'),
+                            dst=os.path.join(source_dir, 'annotation'))

--- a/S1_NRB/nrb.py
+++ b/S1_NRB/nrb.py
@@ -20,7 +20,7 @@ from S1_NRB import dem
 from S1_NRB.metadata import extract, xml, stac
 from S1_NRB.metadata.mapping import ITEM_MAP
 from S1_NRB.ancillary import generate_unique_id, vrt_add_overviews
-from S1_NRB.metadata.extract import etree_from_sid, find_in_annotation
+from S1_NRB.metadata.extract import copy_src_meta, etree_from_sid, find_in_annotation
 from S1_NRB.snap import find_datasets
 
 
@@ -342,6 +342,7 @@ def format(config, scenes, datadir, outdir, tile, extent, epsg, wbm=None,
                              proc_time=proc_time, start=start, stop=stop, compression=compress)
     xml.parse(meta=meta, target=nrb_dir, tifs=list(datasets_nrb.values()), exist_ok=True)
     stac.parse(meta=meta, target=nrb_dir, tifs=list(datasets_nrb.values()), exist_ok=True)
+    copy_src_meta(target=nrb_dir, src_ids=src_ids)
     return str(round((time.time() - start_time), 2))
 
 


### PR DESCRIPTION
This saves the original source metadata in the `source` folder of the processed scene, including the `manifest.safe` and the content of the `annotation` directory.

Currently a subdirectory based on the `productIdentifier` is created to save the files:

<img width="915" alt="image" src="https://github.com/SAR-ARD/S1_NRB/assets/56583917/33e88a5c-ba93-4de7-9488-1eb4c2abaabf">

Another option would be to use the complete name for the directory. E.g., in this case `S1B_IW_GRDH_1SDV_20211114T190500_20211114T190525_029588_0387F4_527F`. Thoughts @johntruckenbrodt ?
