### PR TITLE
do not continue on error

### DIFF
--- a/S1_NRB/processor.py
+++ b/S1_NRB/processor.py
@@ -196,6 +196,7 @@ def main(config_file, section_name='PROCESSING', debug=False, **kwargs):
             # otherwise there will be a gap between final geocoded images.
             neighbors = None
             if scene.product == 'GRD':
+                print('###### [    RTC] collecting GRD neighbors')
                 f = '%Y%m%dT%H%M%S'
                 td = timedelta(seconds=2)
                 start = datetime.strptime(scene.start, f) - td
@@ -247,7 +248,7 @@ def main(config_file, section_name='PROCESSING', debug=False, **kwargs):
                 anc.log(handler=logger, mode='info', proc_step='RTC', scenes=scene.scene, msg=t)
             except Exception as e:
                 anc.log(handler=logger, mode='exception', proc_step='RTC', scenes=scene.scene, msg=e)
-                continue
+                raise
     ####################################################################################################################
     # NRB - final product generation
     if nrb_flag:
@@ -304,6 +305,6 @@ def main(config_file, section_name='PROCESSING', debug=False, **kwargs):
                     anc.log(handler=logger, mode='info', proc_step='NRB', scenes=scenes_sub_fnames, msg=msg)
                 except Exception as e:
                     anc.log(handler=logger, mode='exception', proc_step='NRB', scenes=scenes_sub_fnames, msg=e)
-                    continue
+                    raise
             del tiles
         gdal.SetConfigOption('GDAL_NUM_THREADS', gdal_prms['threads_before'])


### PR DESCRIPTION
The processor used to continue if there was an error during SAR processing or NRB tile creation. The logic was to not completely stop the processor in case (only) one scene fails. However, in its current state the processor needs to make sure the output of all scenes is created to create complete NRB tiles afterwards. hence, output of all scenes is necessary.
Now, the error is catched so that it can be written to the log file but raised afterwards so that the processor stops.