### PR TITLE
New metadata config parameters

### DIFF
--- a/S1_NRB/config.py
+++ b/S1_NRB/config.py
@@ -92,7 +92,6 @@ def get_config(config_file, proc_section='PROCESSING', **kwargs):
         proc_sec['snap_gpt_args'] = 'None'
     if 'datatake' not in proc_sec.keys():
         proc_sec['datatake'] = 'None'
-    
     # use previous defaults for measurement and annotation if they have not been defined
     if 'measurement' not in proc_sec.keys():
         proc_sec['measurement'] = 'gamma'
@@ -166,10 +165,7 @@ def get_config(config_file, proc_section='PROCESSING', **kwargs):
                        'Copernicus 30m Global DEM', 'GETASSE30']
             assert v in allowed, "Parameter '{}': expected to be one of {}; got '{}' instead".format(k, allowed, v)
         if k in ['etad', 'date_strict']:
-            try:
-                v = proc_sec.getboolean(k)
-            except ValueError:
-                raise RuntimeError(f"cannot parse boolean parameter '{k}' with value '{v}'")
+            v = proc_sec.getboolean(k)
         if k == 'product':
             allowed = ['GRD', 'SLC']
             assert v in allowed, "Parameter '{}': expected to be one of {}; got '{}' instead".format(k, allowed, v)
@@ -263,10 +259,7 @@ def _parse_list(s):
     if s in ['', 'None']:
         return None
     else:
-        if re.search(',', s):
-            return s.replace(' ', '').split(',')
-        else:
-            return s.split()
+        return [x.strip() for x in s.split(',')]
 
 
 def _keyval_check(key, val, allowed_keys):

--- a/S1_NRB/nrb.py
+++ b/S1_NRB/nrb.py
@@ -340,9 +340,12 @@ def format(config, scenes, datadir, outdir, tile, extent, epsg, wbm=None,
     stop = datetime.strptime(nrb_stop, '%Y%m%dT%H%M%S')
     meta = extract.meta_dict(config=config, target=nrb_dir, src_ids=src_ids, rtc_dir=datadir,
                              proc_time=proc_time, start=start, stop=stop, compression=compress)
-    xml.parse(meta=meta, target=nrb_dir, tifs=list(datasets_nrb.values()), exist_ok=True)
-    stac.parse(meta=meta, target=nrb_dir, tifs=list(datasets_nrb.values()), exist_ok=True)
-    copy_src_meta(target=nrb_dir, src_ids=src_ids)
+    if 'OGC' in config['meta']['format']:
+        xml.parse(meta=meta, target=nrb_dir, tifs=list(datasets_nrb.values()), exist_ok=True)
+    if 'STAC' in config['meta']['format']:
+        stac.parse(meta=meta, target=nrb_dir, tifs=list(datasets_nrb.values()), exist_ok=True)
+    if config['meta']['copy_original']:
+        copy_src_meta(target=nrb_dir, src_ids=src_ids)
     return str(round((time.time() - start_time), 2))
 
 

--- a/config.ini
+++ b/config.ini
@@ -126,12 +126,20 @@ etad_dir = /example/etad/directory
 
 
 [METADATA]
+
+# The metadata file format(s). OPTIONS:
+# - OGC (XML file according to OGC EO standard)
+# - STAC (JSON)
+format = OGC, STAC
+
+# Copy the original metadata of the source scene(s)? (includes: manifest.safe and annotation folder)
+copy_original = True
+
 # The metadata files created for each S1-NRB product contain some fields that should not be hidden away and hardcoded
 # with arbitrary values. Instead, they can be accessed here in order to more easily generate a complete set of metadata.
 # These fields are mostly relevant if you want to produce S1-NRB products systematically and make them available for
 # others. If you don't see a need for them you can just leave the fields empty, use the default 'None' or delete this
 # entire section.
-
 access_url = None
 licence = None
 doi = None

--- a/docs/general/usage.rst
+++ b/docs/general/usage.rst
@@ -9,9 +9,18 @@ opened with any text editor. An example ``config.ini`` file for the S1_NRB packa
 
 https://github.com/SAR-ARD/S1_NRB/blob/main/config.ini
 
+Configuration files in INI format can have different sections. Each section begins at a section name and ends at the next
+section name. The ``config.ini`` file used with the S1_NRB package should at least have a dedicated section for processing
+related parameters. This section is by default named ``[PROCESSING]``.
+Users might create several processing sections in the same configuration file with parameter values that correspond to different
+processing scenarios (e.g., for different areas of interest). Note that each section must contain all necessary
+configuration parameters even if only a few are varied between the sections.
+
 The following provides an overview of the parameters the ``config.ini`` should contain and anything that should be
 considered when selecting their values:
 
+Processing Section
+^^^^^^^^^^^^^^^^^^
 - **mode**
 
 Options: ``all | nrb | rtc``
@@ -145,24 +154,26 @@ should be performed or not. If ``etad=True``, ``etad_dir`` is searched for ETAD 
 and a new SLC is created in ``tmp_dir``, which is then used for all other processing steps. If ``etad=False``, ``etad_dir``
 will be ignored.
 
-Sections
-^^^^^^^^
-Configuration files in INI format can have different sections. Each section begins at a section name and ends at the next
-section name. The ``config.ini`` file used with the S1_NRB package should at least have a dedicated section for processing
-related parameters. This section is by default named ``[PROCESSING]``
-(see `example config file <https://github.com/SAR-ARD/S1_NRB/blob/main/config.ini>`_).
+Metadata Section
+^^^^^^^^^^^^^^^^
+- **format**
 
-A reserved section ``[METADATA]`` may contain user-specific metadata to be written to the product's metadata files.
-Currently supported fields:
+A comma-separated list to define the metadata file formats to be created. Supported options:
 
- + access_url
- + licence
- + doi
- + processing_center
+ + OGC: XML file according to `OGC EO <https://docs.ogc.org/is/10-157r4/10-157r4.html>`_ standard
+ + STAC: JSON file according to the `SpatioTemporal Asset Catalog <https://github.com/radiantearth/stac-spec/>`_ family of specifications
 
-Users might create several processing sections in the same configuration file with parameter values that correspond to different
-processing scenarios (e.g., for different areas of interest). Note that each section must contain all necessary
-configuration parameters even if only a few are varied between the sections.
+- **copy_original**
+
+Copy the original metadata of the source scene(s)? This will copy the manifest.safe file and annotation folder into the
+S1-NRB product subdirectory: ``/source/<ProductIdentifier>``.
+
+- **access_url**, **licence**, **doi** & **processing_center**
+
+The metadata files created for each S1-NRB product contain some fields that should not be hidden away and hardcoded with
+arbitrary values. Instead, they can be accessed here in order to more easily generate a complete set of metadata. These
+fields are mostly relevant if you want to produce S1-NRB products systematically and make them available for others.
+If you don't see a need for them you can just leave the fields empty, use the default 'None' or delete this entire section.
 
 Command Line Interface
 ----------------------


### PR DESCRIPTION
- new config parameters in `METADATA`-section:  
    - `format` to select between metadata file formats (OGC EO XML and/or STAC JSON)
    - `copy_original` to optionally copy the original source metadata
- documentation improvements in _general/usage_