### PR TITLE
Replace `gs` and `sg` annotation options with `ratio`

### DIFF
--- a/S1_NRB/config.py
+++ b/S1_NRB/config.py
@@ -217,7 +217,7 @@ def _parse_annotation(s):
     https://docs.python.org/3/library/configparser.html#customizing-parser-behaviour"""
     annotation_list = _parse_list(s)
     if annotation_list is not None:
-        allowed = ['dm', 'ei', 'em', 'id', 'lc', 'li', 'np', 'gs', 'sg']
+        allowed = ['dm', 'ei', 'em', 'id', 'lc', 'li', 'np', 'ratio']
         for annotation in annotation_list:
             if annotation not in allowed:
                 msg = "Parameter 'annotation': Error while parsing to list; " \

--- a/S1_NRB/config.py
+++ b/S1_NRB/config.py
@@ -218,11 +218,11 @@ def _parse_annotation(s):
     annotation_list = _parse_list(s)
     if annotation_list is not None:
         allowed = ['dm', 'ei', 'em', 'id', 'lc', 'li', 'np', 'ratio']
-        for annotation in annotation_list:
-            if annotation not in allowed:
+        for layer in annotation_list:
+            if layer not in allowed:
                 msg = "Parameter 'annotation': Error while parsing to list; " \
-                      "annotation '{}' is not supported. Allowed keys:\n{}"
-                raise ValueError(msg.format(annotation, allowed))
+                      "layer '{}' is not supported. Allowed keys:\n{}"
+                raise ValueError(msg.format(layer, allowed))
     return annotation_list
 
 

--- a/S1_NRB/processor.py
+++ b/S1_NRB/processor.py
@@ -154,6 +154,8 @@ def main(config_file, section_name='PROCESSING', debug=False, **kwargs):
               'sg': 'sigmaGammaRatio'}
     
     if annotation is not None:
+        annotation = ['gs' if x == 'ratio' and measurement == 'gamma' else 'sg' if x == 'ratio'
+                      else x for x in annotation]
         export_extra = []
         for layer in annotation:
             if layer in lookup:

--- a/config.ini
+++ b/config.ini
@@ -112,12 +112,13 @@ measurement = gamma
 # lc: RTC local contributing area
 # li: local incident angle
 # np: noise power (NESZ, per polarization)
-# gs: gamma-sigma ratio: sigma0 RTC / gamma0 RTC (ignored if measurement is not gamma)
-# sg: sigma-gamma ratio: gamma0 RTC / sigma0 ellipsoidal (ignored if measurement is not sigma)
+# ratio: will automatically be replaced with the following, depending on selected [measurement]:
+#     gs: gamma-sigma ratio: sigma0 RTC / gamma0 RTC (if [measurement] = gamma)
+#     sg: sigma-gamma ratio: gamma0 RTC / sigma0 ellipsoidal (if [measurement] = sigma)
 # Use one of the following to create no annotation layer:
 # annotation =
 # annotation = None
-annotation = dm, ei, em, id, lc, li, np, gs
+annotation = dm, ei, em, id, lc, li, np, ratio
 
 # Should ETAD correction be performed on SLCs? If [etad] is False, [etad_dir] will be ignored,
 # otherwise [etad_dir] is searched recursively for ETAD products matching the defined SLCs.

--- a/docs/general/usage.rst
+++ b/docs/general/usage.rst
@@ -130,8 +130,10 @@ A comma-separated list to define the annotation layers to be created. Supported 
  + lc: RTC local contributing area
  + li: local incident angle
  + np: noise power (NESZ, per polarization)
- + gs: gamma-sigma ratio: sigma0 RTC / gamma0 RTC (ignored if ``measurement`` is not gamma)
- + sg: sigma-gamma ratio: gamma0 RTC / sigma0 ellipsoidal (ignored if ``measurement`` is not sigma)
+ + ratio: will automatically be replaced with the following, depending on selected ``measurement``:
+
+   + gs: gamma-sigma ratio: sigma0 RTC / gamma0 RTC (if ``measurement = gamma``)
+   + sg: sigma-gamma ratio: gamma0 RTC / sigma0 ellipsoidal (if ``measurement = sigma``)
 
 Use one of the following to create no annotation layer:
 


### PR DESCRIPTION
The annotation options `gs` and `sg` depend on which measurement option was chosen (`gamma` or `sigma`). This is easily missed in the config file and users might end up without any of these conversion layers after processing. 
I propose to change this option from:

```ini
# gs: gamma-sigma ratio: sigma0 RTC / gamma0 RTC (ignored if measurement is not gamma)
# sg: sigma-gamma ratio: gamma0 RTC / sigma0 ellipsoidal (ignored if measurement is not sigma)
```
to: 
```ini
# ratio: will automatically be replaced with the following, depending on selected [measurement]:
#     gs: gamma-sigma ratio: sigma0 RTC / gamma0 RTC (if [measurement] = gamma)
#     sg: sigma-gamma ratio: gamma0 RTC / sigma0 ellipsoidal (if [measurement] = sigma)
```
