### PR TITLE
[nrb.create_vrt] fixed bug in handling default 'options=None'

### DIFF
--- a/S1_NRB/nrb.py
+++ b/S1_NRB/nrb.py
@@ -505,6 +505,7 @@ def create_vrt(src, dst, fun, relpaths=False, scale=None, offset=None, args=None
     >>> dst = src.replace('-lin.tif', '-log3.vrt')
     >>> create_vrt(src=src, dst=dst, fun='dB', args={'fact': 10})
     """
+    options = {} if options is None else options
     gdalbuildvrt(src=src, dst=dst, **options)
     tree = etree.parse(dst)
     root = tree.getroot()


### PR DESCRIPTION
Leaving [nrb.create_vrt](https://s1-nrb.readthedocs.io/en/latest/api.html#S1_NRB.nrb.create_vrt) parameter `options` at its default `None` did not work with
```python
gdalbuildvrt(src=src, dst=dst, **options)
```