### PR TITLE
rename config default annotation IDs gs and sg to ratio

### DIFF
--- a/S1_NRB/config.py
+++ b/S1_NRB/config.py
@@ -97,9 +97,9 @@ def get_config(config_file, proc_section='PROCESSING', **kwargs):
         proc_sec['measurement'] = 'gamma'
     if 'annotation' not in proc_sec.keys():
         if proc_sec['measurement'] == 'gamma':
-            proc_sec['annotation'] = 'dm,ei,id,lc,li,np,gs'
+            proc_sec['annotation'] = 'dm,ei,id,lc,li,np,ratio'
         else:
-            proc_sec['annotation'] = 'dm,ei,id,lc,li,np,sg'
+            proc_sec['annotation'] = 'dm,ei,id,lc,li,np,ratio'
     
     # check completeness of configuration parameters
     missing = []


### PR DESCRIPTION
https://github.com/SAR-ARD/S1_NRB/pull/116 renamed the backscatter ratio IDs `sg` and `gs` to `ratio`. Renaming the defaults applied when the configuration file does not have an `annotation` attribute was missed.