### PR TITLE
XML product metadata improvements

### DIFF
--- a/S1_NRB/metadata/extract.py
+++ b/S1_NRB/metadata/extract.py
@@ -156,9 +156,10 @@ def meta_dict(config, target, src_ids, sar_dir, proc_time, start, stop, compress
     meta['prod']['griddingConvention'] = 'Military Grid Reference System (MGRS)'
     meta['prod']['licence'] = config['meta']['licence']
     meta['prod']['mgrsID'] = prod_meta['mgrsID']
-    meta['prod']['NRApplied'] = True
-    meta['prod']['NRAlgorithm'] = 'https://sentinel.esa.int/documents/247904/2142675/Thermal-Denoising-of-Products-' \
-                                  'Generated-by-Sentinel-1-IPF' if meta['prod']['NRApplied'] else None
+    meta['prod']['noiseRemovalApplied'] = True
+    nr_algo = 'https://sentinel.esa.int/documents/247904/2142675/Thermal-Denoising-of-Products-Generated-by-' \
+              'Sentinel-1-IPF' if meta['prod']['noiseRemovalApplied'] else None
+    meta['prod']['noiseRemovalAlgorithm'] = nr_algo
     meta['prod']['numberOfAcquisitions'] = str(len(src_sid))
     meta['prod']['numBorderPixels'] = prod_meta['nodata_borderpx']
     meta['prod']['numLines'] = str(prod_meta['rows'])

--- a/S1_NRB/metadata/stac.py
+++ b/S1_NRB/metadata/stac.py
@@ -263,7 +263,7 @@ def product_json(meta, target, assets, exist_ok=False):
     item.properties['card4l:measurement_convention'] = meta['prod']['backscatterConvention']
     item.properties['card4l:pixel_coordinate_convention'] = meta['prod']['pixelCoordinateConvention']
     item.properties['card4l:speckle_filtering'] = meta['prod']['speckleFilterApplied']
-    item.properties['card4l:noise_removal_applied'] = meta['prod']['NRApplied']
+    item.properties['card4l:noise_removal_applied'] = meta['prod']['noiseRemovalApplied']
     item.properties['card4l:conversion_eq'] = meta['prod']['backscatterConversionEq']
     item.properties['card4l:relative_radiometric_accuracy'] = meta['prod']['radiometricAccuracyRelative']
     item.properties['card4l:absolute_radiometric_accuracy'] = meta['prod']['radiometricAccuracyAbsolute']
@@ -308,9 +308,9 @@ def product_json(meta, target, assets, exist_ok=False):
                                    target=meta['prod']['ancillaryData_KML'],
                                    title='Sentinel-2 Military Grid Reference System (MGRS) tiling grid file '
                                          'used as auxiliary data during processing.'))
-    if meta['prod']['NRApplied']:
+    if meta['prod']['noiseRemovalApplied']:
         item.add_link(link=pystac.Link(rel='noise-removal',
-                                       target=meta['prod']['NRAlgorithm'],
+                                       target=meta['prod']['noiseRemovalAlgorithm'],
                                        title='Reference to the noise removal algorithm details.'))
     if meta['prod']['RTCAlgorithm'] is not None:
         item.add_link(link=pystac.Link(rel='radiometric-terrain-correction',

--- a/S1_NRB/metadata/xml.py
+++ b/S1_NRB/metadata/xml.py
@@ -413,11 +413,13 @@ def product_xml(meta, target, assets, nsmap, ard_ns, exist_ok=False):
     speckleFilterApplied = etree.SubElement(processingInformation, _nsc('_:speckleFilterApplied', nsmap,
                                                                         ard_ns=ard_ns))
     speckleFilterApplied.text = str(meta['prod']['speckleFilterApplied']).lower()
-    nrApplied = etree.SubElement(processingInformation, _nsc('_:NRApplied', nsmap, ard_ns=ard_ns))
-    nrApplied.text = str(meta['prod']['NRApplied']).lower()
-    if meta['prod']['NRApplied']:
-        nrAlgorithm = etree.SubElement(processingInformation, _nsc('_:NRAlgorithm', nsmap, ard_ns=ard_ns),
-                                       attrib={_nsc('xlink:href', nsmap): meta['prod']['NRAlgorithm']})
+    noiseRemovalApplied = etree.SubElement(processingInformation, _nsc('_:noiseRemovalApplied', nsmap, ard_ns=ard_ns))
+    noiseRemovalApplied.text = str(meta['prod']['noiseRemovalApplied']).lower()
+    if meta['prod']['noiseRemovalApplied']:
+        noiseRemovalAlgorithm = etree.SubElement(processingInformation,
+                                                 _nsc('_:noiseRemovalAlgorithm', nsmap, ard_ns=ard_ns),
+                                                 attrib={_nsc('xlink:href', nsmap):
+                                                         meta['prod']['noiseRemovalAlgorithm']})
     if meta['prod']['RTCAlgorithm'] is not None:
         rtcAlgorithm = etree.SubElement(processingInformation, _nsc('_:RTCAlgorithm', nsmap, ard_ns=ard_ns),
                                         attrib={_nsc('xlink:href', nsmap): meta['prod']['RTCAlgorithm']})

--- a/S1_NRB/metadata/xml.py
+++ b/S1_NRB/metadata/xml.py
@@ -327,6 +327,11 @@ def product_xml(meta, target, assets, nsmap, ard_ns, exist_ok=False):
             if re.search(np_pat, key) is not None:
                 key = np_pat
             
+            sampleType = etree.SubElement(productInformation, _nsc('_:sampleType', nsmap, ard_ns=ard_ns),
+                                          attrib={'uom': 'unitless' if ASSET_MAP[key]['unit'] is None else
+                                                         ASSET_MAP[key]['unit']})
+            sampleType.text = ASSET_MAP[key]['type']
+            
             if key in ['-dm.tif', '-id.tif']:
                 dataType.text = 'UINT'
                 bitsPerSample.text = '8'
@@ -350,12 +355,6 @@ def product_xml(meta, target, assets, nsmap, ard_ns, exist_ok=False):
                         bitValue = etree.SubElement(productInformation, _nsc('_:bitValue', nsmap, ard_ns=ard_ns),
                                                     attrib={'band': '1', 'name': s})
                         bitValue.text = str(i + 1)
-            
-            if ASSET_MAP[key]['unit'] is None:
-                ASSET_MAP[key]['unit'] = 'unitless'
-            sampleType = etree.SubElement(productInformation, _nsc('_:sampleType', nsmap, ard_ns=ard_ns),
-                                          attrib={'uom': ASSET_MAP[key]['unit']})
-            sampleType.text = ASSET_MAP[key]['type']
             
             if key == '-ei.tif':
                 ellipsoidalHeight = etree.SubElement(productInformation, _nsc('_:ellipsoidalHeight', nsmap,

--- a/S1_NRB/nrb.py
+++ b/S1_NRB/nrb.py
@@ -345,7 +345,9 @@ def format(config, product_type, scenes, datadir, outdir, tile, extent, epsg, wb
     meta = extract.meta_dict(config=config, target=ard_dir, src_ids=src_ids, sar_dir=datadir,
                              proc_time=proc_time, start=start, stop=stop, compression=compress,
                              product_type=product_type)
-    ard_assets = list(datasets_ard.values()) + finder(ard_dir, ['.vrt$'], regex=True, recursive=True)
+    ard_assets = sorted(sorted(list(datasets_ard.values()) + finder(ard_dir, ['.vrt$'], regex=True, recursive=True),
+                               key=lambda x: os.path.splitext(x)[1]),
+                        key=lambda x: os.path.basename(os.path.dirname(x)), reverse=True)
     if 'OGC' in config['meta']['format']:
         xml.parse(meta=meta, target=ard_dir, assets=ard_assets, exist_ok=True)
     if 'STAC' in config['meta']['format']:


### PR DESCRIPTION
Some minor improvements to align with the Product Specification v1.1:
- Rename `NRApplied` & `NRAlgorithm` to `noiseRemovalApplied` & `noiseRemovalAlgorithm` (d468308ab30bf7851b6092cad2be7b60f0d99b45)
- Move `sampleType` field before `bitValue` (5e9c3eb2cd60e2179db825c2b746f67250fe550d)

...and align (not perfectly, but much better) with the STAC product metadata:
- Improve the order of assets listed in the XML metadata (eccef9a0626fed46d03cd740f245d7cd74604f0e)
