### PR TITLE
wind normalization

### DIFF
--- a/S1_NRB/config.py
+++ b/S1_NRB/config.py
@@ -223,7 +223,7 @@ def _parse_annotation(s):
     https://docs.python.org/3/library/configparser.html#customizing-parser-behaviour"""
     annotation_list = _parse_list(s)
     if annotation_list is not None:
-        allowed = ['dm', 'ei', 'em', 'id', 'lc', 'ld', 'li', 'np', 'ratio']
+        allowed = ['dm', 'ei', 'em', 'id', 'lc', 'ld', 'li', 'np', 'ratio', 'wm']
         for layer in annotation_list:
             if layer not in allowed:
                 msg = "Parameter 'annotation': Error while parsing to list; " \

--- a/S1_NRB/metadata/extract.py
+++ b/S1_NRB/metadata/extract.py
@@ -594,7 +594,7 @@ def calc_enl(tif, block_size=30, return_arr=False):
     if num_blocks_rows == 0 or num_blocks_cols == 0:
         raise ValueError("Block size is too large for the input data dimensions.")
     blocks = arr[:num_blocks_rows * block_size,
-                 :num_blocks_cols * block_size].reshape(num_blocks_rows, block_size, num_blocks_cols, block_size)
+             :num_blocks_cols * block_size].reshape(num_blocks_rows, block_size, num_blocks_cols, block_size)
     
     with np.testing.suppress_warnings() as sup:
         sup.filter(RuntimeWarning, "Mean of empty slice")
@@ -768,6 +768,7 @@ def get_header_size(tif):
     header_size: int
         The size of all IFD headers of the GeoTIFF file in bytes.
     """
+    
     def _get_block_offset(band):
         blockxsize, blockysize = band.GetBlockSize()
         for y in range(int((band.YSize + blockysize - 1) / blockysize)):
@@ -818,11 +819,13 @@ def copy_src_meta(target, src_ids):
         
         if src_id.scene.endswith('.zip'):
             base = os.path.basename(src_id.file)
-            with zipfile.ZipFile(src_id.scene, 'r') as zip_ref:
-                zip_ref.extract(member=base + '/manifest.safe', path=source_dir)
-                annotation_files = [f for f in zip_ref.namelist() if base + '/annotation' in f]
-                zip_ref.extractall(members=annotation_files, path=source_dir)
-            os.rename(os.path.join(source_dir, base), os.path.join(source_dir, pid))
+            target = os.path.join(source_dir, pid)
+            if not os.path.isdir(target):
+                with zipfile.ZipFile(src_id.scene, 'r') as zip_ref:
+                    zip_ref.extract(member=base + '/manifest.safe', path=source_dir)
+                    annotation_files = [f for f in zip_ref.namelist() if base + '/annotation' in f]
+                    zip_ref.extractall(members=annotation_files, path=source_dir)
+                os.rename(os.path.join(source_dir, base), target)
         else:
             pid_dir = os.path.join(source_dir, pid)
             os.makedirs(pid_dir, exist_ok=True)

--- a/S1_NRB/metadata/extract.py
+++ b/S1_NRB/metadata/extract.py
@@ -797,14 +797,14 @@ def get_header_size(tif):
     return headers_size
 
 
-def copy_src_meta(target, src_ids):
+def copy_src_meta(ard_dir, src_ids):
     """
     Copies the original metadata of the source scenes to the ARD product
     directory.
     
     Parameters
     ----------
-    target: str
+    ard_dir: str
         A path pointing to the current ARD product directory.
     src_ids: list[pyroSAR.drivers.ID]
         List of :class:`~pyroSAR.drivers.ID` objects of all source scenes that overlap with the current MGRS tile.
@@ -814,7 +814,7 @@ def copy_src_meta(target, src_ids):
     None
     """
     for src_id in src_ids:
-        source_dir = os.path.join(target, 'source')
+        source_dir = os.path.join(ard_dir, 'source')
         pid = re.match(src_id.pattern, os.path.basename(src_id.file)).group('productIdentifier')
         
         if src_id.scene.endswith('.zip'):

--- a/S1_NRB/metadata/mapping.py
+++ b/S1_NRB/metadata/mapping.py
@@ -160,10 +160,10 @@ ASSET_MAP = {'-dm.tif': {'type': 'Mask',
                          'unit': None,
                          'role': 'sigma-gamma-ratio',
                          'title': 'Sigma0 ellipsoidal to gamma0 RTC ratio'},
-             '-wm.tif': {'type': 'wind-modeled-backscatter',
+             '-wm.tif': {'type': 'wind-modelled-backscatter',
                          'unit': None,
-                         'role': 'wind-modeled-backscatter',
-                         'title': 'wind-modeled backscatter (OCN CMOD NRCS)'}}
+                         'role': 'wind-modelled-backscatter',
+                         'title': 'wind-modelled backscatter (OCN CMOD NRCS)'}}
 
 # https://sentinel.esa.int/documents/247904/1653442/Guide-to-Sentinel-1-Geocoding.pdf
 SLC_ACC_MAP = {'SM': {'ALE': {'rg': -3.02,

--- a/S1_NRB/metadata/mapping.py
+++ b/S1_NRB/metadata/mapping.py
@@ -159,7 +159,11 @@ ASSET_MAP = {'-dm.tif': {'type': 'Mask',
              '-sg.tif': {'type': 'Ratio',
                          'unit': None,
                          'role': 'sigma-gamma-ratio',
-                         'title': 'Sigma0 ellipsoidal to gamma0 RTC ratio'}}
+                         'title': 'Sigma0 ellipsoidal to gamma0 RTC ratio'},
+             '-wm.tif': {'type': 'wind-modeled-backscatter',
+                         'unit': None,
+                         'role': 'wind-modeled-backscatter',
+                         'title': 'wind-modeled backscatter (OCN CMOD5n NRCS)'}}
 
 # https://sentinel.esa.int/documents/247904/1653442/Guide-to-Sentinel-1-Geocoding.pdf
 SLC_ACC_MAP = {'SM': {'ALE': {'rg': -3.02,

--- a/S1_NRB/metadata/mapping.py
+++ b/S1_NRB/metadata/mapping.py
@@ -163,7 +163,7 @@ ASSET_MAP = {'-dm.tif': {'type': 'Mask',
              '-wm.tif': {'type': 'wind-modeled-backscatter',
                          'unit': None,
                          'role': 'wind-modeled-backscatter',
-                         'title': 'wind-modeled backscatter (OCN CMOD5n NRCS)'}}
+                         'title': 'wind-modeled backscatter (OCN CMOD NRCS)'}}
 
 # https://sentinel.esa.int/documents/247904/1653442/Guide-to-Sentinel-1-Geocoding.pdf
 SLC_ACC_MAP = {'SM': {'ALE': {'rg': -3.02,

--- a/S1_NRB/metadata/stac.py
+++ b/S1_NRB/metadata/stac.py
@@ -433,8 +433,13 @@ def _asset_get_key_title(meta, asset):
     key = None
     title = None
     if 'measurement' in asset:
-        title_dict = {'g': 'gamma nought', 's': 'sigma nought', 'lin': 'linear', 'log': 'logarithmic'}
-        info = re.search('(?P<key>(?P<pol>[vhc]{2})-(?P<nought>[gs])-(?P<scaling>lin|log))', asset).groupdict()
+        title_dict = {'g': 'gamma nought', 's': 'sigma nought',
+                      'lin': 'linear', 'log': 'logarithmic'}
+        pattern = ('(?P<key>(?P<pol>[vhc]{2})-'
+                   '(?P<nought>[gs])-'
+                   '(?P<scaling>lin|log)'
+                   '(?P<windnorm>-wn|))')
+        info = re.search(pattern, asset).groupdict()
         key = info['key']
         
         if re.search('cc-[gs]-lin', key):
@@ -449,7 +454,10 @@ def _asset_get_key_title(meta, asset):
                                  cross=cross.lower(),
                                  nought=info['nought'])
         else:
-            skeleton = '{pol} {nought} {subtype} backscatter, {scale} scaling'
+            if info['windnorm'] == '-wn':
+                skeleton = '{pol} {nought} {subtype} wind normalisation ratio, {scale} scaling'
+            else:
+                skeleton = '{pol} {nought} {subtype} backscatter, {scale} scaling'
             subtype = 'RTC' if info['nought'] == 'g' else 'ellipsoidal'
             title = skeleton.format(pol=info['pol'].upper(),
                                     nought=title_dict[info['nought']],

--- a/S1_NRB/nrb.py
+++ b/S1_NRB/nrb.py
@@ -391,7 +391,7 @@ def format(config, product_type, scenes, datadir, outdir, tile, extent, epsg, wb
                              product_type=product_type)
     ard_assets = list(datasets_ard.values())
     if config['meta']['copy_original']:
-        copy_src_meta(target=ard_dir, src_ids=src_ids)
+        copy_src_meta(ard_dir=ard_dir, src_ids=src_ids)
     if 'OGC' in config['meta']['format']:
         xml.parse(meta=meta, target=ard_dir, assets=ard_assets, exist_ok=True)
     if 'STAC' in config['meta']['format']:

--- a/S1_NRB/nrb.py
+++ b/S1_NRB/nrb.py
@@ -79,6 +79,7 @@ def format(config, product_type, scenes, datadir, outdir, tile, extent, epsg, wb
         - em: digital elevation model
         - id: acquisition ID image (source scene ID per pixel)
         - lc: RTC local contributing area
+        - ld: range look direction angle
         - li: local incident angle
         - np: noise power (NESZ, per polarization)
         - gs: gamma-sigma ratio: sigma0 RTC / gamma0 RTC

--- a/S1_NRB/nrb.py
+++ b/S1_NRB/nrb.py
@@ -16,7 +16,7 @@ from spatialist.auxil import gdalwarp, gdalbuildvrt
 from spatialist.ancillary import finder
 from pyroSAR import identify, identify_many
 import S1_NRB
-from S1_NRB import dem
+from S1_NRB import dem, ocn
 from S1_NRB.metadata import extract, xml, stac
 from S1_NRB.metadata.mapping import LERC_ERR_THRES
 from S1_NRB.ancillary import generate_unique_id, vrt_add_overviews
@@ -83,6 +83,7 @@ def format(config, product_type, scenes, datadir, outdir, tile, extent, epsg, wb
         - np: noise power (NESZ, per polarization)
         - gs: gamma-sigma ratio: sigma0 RTC / gamma0 RTC
         - sg: sigma-gamma ratio: gamma0 RTC / sigma0 ellipsoidal
+        - wm: OCN product wind model; requires OCN scenes via argument `scenes_ocn`
     update: bool
         modify existing products so that only missing files are re-created?
     
@@ -101,6 +102,7 @@ def format(config, product_type, scenes, datadir, outdir, tile, extent, epsg, wb
     dst_nodata_float = -9999.0
     dst_nodata_byte = 255
     vrt_nodata = 'nan'  # was found necessary for proper calculation of statistics in QGIS
+    vrt_options = {'VRTNodata': vrt_nodata}
     
     # determine processing timestamp and generate unique ID
     start_time = time.time()
@@ -273,9 +275,7 @@ def format(config, product_type, scenes, datadir, outdir, tile, extent, epsg, wb
             create_rgb_vrt(outname=cc_path, infiles=measure_tifs,
                            overviews=overviews, overview_resampling=ovr_resampling)
     
-    vrt_options = {'VRTNodata': vrt_nodata}
-    
-    # create log-scaled gamma0/sigma0 nought VRTs (-[vh|vv|hh|hv]-[gs]-log.vrt)
+    # create log-scaled gamma0|sigma0 nought VRTs (-[vh|vv|hh|hv]-[gs]-log.vrt)
     fun = 'dB'
     args = {'fact': 10}
     scale = None
@@ -299,6 +299,8 @@ def format(config, product_type, scenes, datadir, outdir, tile, extent, epsg, wb
                 create_vrt(src=[item, gs_path], dst=sigma0_rtc_lin, fun='mul',
                            relpaths=True, options=vrt_options, overviews=overviews,
                            overview_resampling=ovr_resampling)
+            key = re.search('[hv]{2}-s-lin', sigma0_rtc_lin).group()
+            datasets_ard[key] = sigma0_rtc_lin
             
             if not os.path.isfile(sigma0_rtc_log):
                 print(sigma0_rtc_log)
@@ -326,6 +328,35 @@ def format(config, product_type, scenes, datadir, outdir, tile, extent, epsg, wb
                 create_vrt(src=gamma0_rtc_lin, dst=gamma0_rtc_log, fun=fun,
                            scale=scale, options=vrt_options, overviews=overviews,
                            overview_resampling=ovr_resampling, args=args)
+    
+    # create backscatter wind model (-wm.tif)
+    # and wind normalization VRT (-[vv|hh]-s-lin-wn.vrt)
+    if 'wm' in annotation:
+        wm = []
+        for i, ds in enumerate(datasets_sar):
+            if 'wm' in ds.keys():
+                wm.append(ds['wm'])
+            else:
+                scene_base = os.path.basename(src_ids[i].scene)
+                raise RuntimeError(f'could not find wind model product for scene {scene_base}')
+        
+        copol = 'VV' if 'VV' in src_ids[0].polarizations else 'HH'
+        copol_sigma0_key = f'{copol.lower()}-s-lin'
+        if copol_sigma0_key in datasets_ard.keys():
+            copol_sigma0 = datasets_ard[copol_sigma0_key]
+            wn_ard = re.sub(r's-lin\.(?:tif|vrt)', 's-lin-wn.vrt', copol_sigma0)
+        else:
+            copol_sigma0 = None
+            wn_ard = None
+        
+        meta_lower['suffix'] = 'wm'
+        outname_base = skeleton_files.format(**meta_lower)
+        wm_ard = os.path.join(ard_dir, 'annotation', outname_base)
+        
+        gapfill = True if src_ids[0].product == 'GRD' else False
+        
+        wind_normalization(src=wm, dst_wm=wm_ard, dst_wn=wn_ard, measurement=copol_sigma0,
+                           gapfill=gapfill, bounds=bounds, epsg=epsg)
     
     # copy support files
     schema_dir = os.path.join(S1_NRB.__path__[0], 'validation', 'schemas')
@@ -398,6 +429,23 @@ def get_datasets(scenes, datadir, extent, epsg):
     for i, _id in enumerate(ids):
         files = find_datasets(scene=_id.scene, outdir=datadir, epsg=epsg)
         if files is not None:
+            
+            base = os.path.splitext(os.path.basename(_id.scene))[0]
+            ocn = re.sub('(?:SLC_|GRD[FHM])_1', 'OCN__2', base)[:-5]
+            # allow 1 second tolerance
+            s_start = int(ocn[31])
+            s_stop = int(ocn[47])
+            ocn_list = list(ocn)
+            s = 1
+            ocn_list[31] = f'[{s_start - s}{s_start}{s_start + s}]'
+            ocn_list[47] = f'[{s_stop - s}{s_stop}{s_stop + s}]'
+            ocn = ''.join(ocn_list)
+            ocn_match = finder(target=datadir, matchlist=[ocn], regex=True, foldermode=2)
+            if len(ocn_match) > 0:
+                cmod = os.path.join(ocn_match[0], 'owiNrcsCmod.tif')
+                if os.path.isfile(cmod):
+                    files['wm'] = cmod
+            
             datasets.append(files)
         else:
             base = os.path.basename(_id.scene)
@@ -870,7 +918,7 @@ def create_data_mask(outname, datasets, extent, epsg, driver, creation_opt,
         ds_tmp.SetProjection(proj)
         
         for i, _dict in enumerate(dm_bands):
-            band = ds_tmp.GetRasterBand(i+1)
+            band = ds_tmp.GetRasterBand(i + 1)
             arr_val = _dict['arr_val']
             b_name = _dict['name']
             
@@ -970,3 +1018,66 @@ def create_acq_id_image(outname, ref_tif, datasets, src_ids, extent,
     with Raster(ref_tif) as ref_ras:
         ref_ras.write(outname, format=driver, array=out_arr.astype('uint8'), nodata=dst_nodata, overwrite=True,
                       overviews=overviews, options=creation_opt)
+
+
+def wind_normalization(src, dst_wm, dst_wn, measurement, gapfill, bounds, epsg, resolution=915):
+    """
+    Create wind normalization layers. A wind model annotation layer is created and optionally
+    a wind normalization VRT.
+    
+    Parameters
+    ----------
+    src: list[str]
+        a list of OCN products as prepared by :func:`S1_NRB.ocn.extract`
+    dst_wm: str
+        the name of the wind model layer in the ARD product
+    dst_wn: str or None
+        the name of the wind normalization VRT. If None, no VRT will be created.
+        Requires `measurement` to point to a file.
+    measurement: str or None
+        the name of the measurement file used for wind normalization in `dst_wn`.
+        If None, no wind normalization VRT will be created.
+    gapfill: bool
+        perform additional gap filling (:func:`S1_NRB.ocn.gapfill`)?
+        This is recommended if the Level-1 source product of `measurement` is GRD
+        in which case gaps are introduced between subsequently acquired scenes.
+    bounds: list[float]
+        the bounds of the MGRS tile
+    epsg: int
+        the EPSG code of the MGRS tile
+    resolution: int
+        the target pixel resolution in meters. 915 is chosen as default because it is closest
+        to the OCN product resolution (1000) and still fits into the MGRS bounds
+        (``109800 % 915 == 0``).
+
+    Returns
+    -------
+
+    """
+    if len(src) > 1:
+        cmod_mosaic = tempfile.NamedTemporaryFile(suffix='.tif').name
+        gdalwarp(src=src, dst=cmod_mosaic)
+        if gapfill:
+            cmod_geo = tempfile.NamedTemporaryFile(suffix='.tif').name
+            ocn.gapfill(src=cmod_mosaic, dst=cmod_geo, md=1, si=1)
+        else:
+            cmod_geo = cmod_mosaic
+    else:
+        cmod_geo = src[0]
+    
+    if not os.path.isfile(dst_wm):
+        print(dst_wm)
+        gdalwarp(src=cmod_geo,
+                 dst=dst_wm,
+                 outputBounds=bounds,
+                 dstSRS=f'EPSG:{epsg}',
+                 xRes=resolution, yRes=resolution,
+                 resampleAlg='bilinear')
+    
+    if dst_wn is not None and measurement is not None:
+        if not os.path.isfile(dst_wn):
+            print(dst_wn)
+            with Raster(measurement) as ras:
+                xres, yres = ras.res
+            create_vrt(src=[measurement, dst_wm], dst=dst_wn, fun='div',
+                       options={'xRes': xres, 'yRes': yres})

--- a/S1_NRB/nrb.py
+++ b/S1_NRB/nrb.py
@@ -280,10 +280,10 @@ def format(config, product_type, scenes, datadir, outdir, tile, extent, epsg, wb
     args = {'fact': 10}
     scale = None
     for item in measure_tifs:
-        gamma0_rtc_log = item.replace('lin.tif', 'log.vrt')
-        if not os.path.isfile(gamma0_rtc_log):
-            print(gamma0_rtc_log)
-            create_vrt(src=item, dst=gamma0_rtc_log, fun=fun, scale=scale,
+        target = item.replace('lin.tif', 'log.vrt')
+        if not os.path.isfile(target):
+            print(target)
+            create_vrt(src=item, dst=target, fun=fun, scale=scale,
                        args=args, options=vrt_options, overviews=overviews,
                        overview_resampling=ovr_resampling)
     

--- a/S1_NRB/ocn.py
+++ b/S1_NRB/ocn.py
@@ -1,0 +1,103 @@
+import numpy as np
+from osgeo import gdal, osr
+from spatialist.ancillary import finder
+
+
+def extract(src, dst, variable):
+    """
+    Extract an OCN product's image variable and write it to a new GeoTIFF file.
+    Coordinates are extracted from the corresponding latitude and longitude
+    image variables and the corner coordinates written as ground control
+    points (GCPs) to the output file.
+
+    Parameters
+    ----------
+    src: str
+        path to OCN product SAFE folder
+    dst: str
+        the name of the GeoTIFF file to write
+    variable: str
+        name of the layer to extract from the OCN product, e.g. `owiNrcsCmod`
+
+    Returns
+    -------
+
+    """
+    ocn_target = finder(target=src, matchlist=['*.nc'])[0]
+    ras_ocn = gdal.Open(f'NETCDF:{ocn_target}:{variable}')
+    arr = ras_ocn.ReadAsArray()
+    lines, samples = arr.shape
+    
+    driver = gdal.GetDriverByName('GTiff')
+    ras_out = driver.CreateCopy(dst, ras_ocn)
+    
+    ras_lat = gdal.Open(f'NETCDF:{ocn_target}:{variable[:3]}Lat')
+    ras_lon = gdal.Open(f'NETCDF:{ocn_target}:{variable[:3]}Lon')
+    arr_lat = ras_lat.ReadAsArray()
+    arr_lon = ras_lon.ReadAsArray()
+    ras_lat = ras_lon = None
+    xres = (np.max(arr_lon) - np.min(arr_lon)) / samples
+    yres = (np.max(arr_lat) - np.min(arr_lat)) / lines
+    # coordinates are at pixel center
+    ulx = float(arr_lon[0, 0]) - xres / 2
+    uly = float(arr_lat[0, 0]) + yres / 2
+    urx = float(arr_lon[0, -1]) - xres / 2
+    ury = float(arr_lat[0, -1]) + yres / 2
+    llx = float(arr_lon[-1, 0]) - xres / 2
+    lly = float(arr_lat[-1, 0]) + yres / 2
+    lrx = float(arr_lon[-1, -1]) - xres / 2
+    lry = float(arr_lat[-1, -1]) + yres / 2
+    gcps = [gdal.GCP(ulx, uly, 0, 0, 0),
+            gdal.GCP(urx, ury, 0, samples, 0),
+            gdal.GCP(lrx, lry, 0, samples, lines),
+            gdal.GCP(llx, lly, 0, 0, lines)]
+    crs = osr.SpatialReference()
+    crs.SetFromUserInput('EPSG:4326')
+    ras_out.SetGCPs(gcps, crs)
+    outband = ras_out.GetRasterBand(1)
+    outband.SetNoDataValue(-999)
+    outband.WriteArray(arr, 0, 0)
+    del arr, arr_lat, arr_lon
+    outband = None
+    ras_out = None
+    ras_ocn = None
+
+
+def gapfill(src, dst, md, si):
+    """
+    Fill gaps of an image file using GDAL.
+
+    Parameters
+    ----------
+    src: str
+        the source image file
+    dst: str
+        the destination image file with gaps filled
+    md: int
+        the interpolation maximum distance
+    si: int
+        the number of smoothing iterations
+
+    Returns
+    -------
+
+    See Also
+    --------
+    osgeo.gdal.FillNodata
+    """
+    ras = gdal.Open(src)
+    band = ras.GetRasterBand(1)
+    
+    driver = gdal.GetDriverByName('GTiff')
+    out = driver.CreateCopy(dst, ras)
+    out_band = out.GetRasterBand(1)
+    arr = band.ReadAsArray()
+    out_band.WriteArray(arr)
+    
+    mask = band.GetMaskBand()
+    result = gdal.FillNodata(out_band, mask, md, si)
+    
+    out_band = None
+    out = None
+    band = None
+    ras = None

--- a/config.ini
+++ b/config.ini
@@ -119,6 +119,7 @@ measurement = gamma
 # ratio: will automatically be replaced with the following, depending on selected [measurement]:
 #     gs: gamma-sigma ratio: sigma0 RTC / gamma0 RTC (if [measurement] = gamma)
 #     sg: sigma-gamma ratio: gamma0 RTC / sigma0 ellipsoidal (if [measurement] = sigma)
+# wm: OCN OWI wind model
 # Use one of the following to create no annotation layer:
 # annotation =
 # annotation = None

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -80,6 +80,7 @@ NRB
         create_vrt
         format
         get_datasets
+        wind_normalization
 
 ETAD
 ^^^^
@@ -107,6 +108,20 @@ DEM
 
         mosaic
         prepare
+
+OCN
+^^^
+
+.. automodule:: S1_NRB.ocn
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+    .. autosummary::
+        :nosignatures:
+
+        extract
+        gapfill
 
 Tile Extraction
 ---------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,7 +51,8 @@ intersphinx_mapping = {'python': ('https://docs.python.org/3', None),
                        'spatialist': ('https://spatialist.readthedocs.io/en/latest', None),
                        'pystac': ('https://pystac.readthedocs.io/en/stable', None),
                        'pystac-client': ('https://pystac-client.readthedocs.io/en/stable', None),
-                       'dateutil': ('https://dateutil.readthedocs.io/en/stable', None)
+                       'dateutil': ('https://dateutil.readthedocs.io/en/stable', None),
+                       'osgeo': ('https://gdal.org', None)
                        }
 
 napoleon_google_docstring = False

--- a/docs/general/usage.rst
+++ b/docs/general/usage.rst
@@ -45,6 +45,7 @@ Search for source scenes within the defined date range.
 Allowed are all string representations that can be parsed by :meth:`dateutil.parser.parse`.
 
 - **date_strict**
+
 Treat dates as strict limits or also allow flexible limits to incorporate scenes
 whose acquisition period overlaps with the defined limit?
 
@@ -146,6 +147,13 @@ Supported options:
 
    + gs: gamma-sigma ratio: sigma0 RTC / gamma0 RTC (if ``measurement = gamma``)
    + sg: sigma-gamma ratio: gamma0 RTC / sigma0 ellipsoidal (if ``measurement = sigma``)
+
+ + wm: wind-modeled backscatter extracted from a Sentinel-1 OCN (ocean) product.
+   The variable `owiNrcsCmod` is used.
+   The OCN products and corresponding Level-1 products must be searchable in the same way.
+   If a sigma naught output layer exists (via ``measurement = sigma`` or `annotation` layer `ratio`),
+   a co-polarization wind normalization ratio VRT is created by dividing the measurement by the
+   wind-modeled backscatter.
 
 Use one of the following to create no annotation layer:
 

--- a/docs/general/usage.rst
+++ b/docs/general/usage.rst
@@ -91,7 +91,8 @@ subdirectories relative to the directory specified with ``work_dir``. E.g., ``ar
 Metadata of any Sentinel-1 scene found in ``scene_dir`` will be stored in an SQLite database file created by :class:`pyrosar.drivers.Archive`.
 With ``db_file`` either a full path to an existing database can be provided or it will be created in ``work_dir`` if only
 a filename is provided. E.g., ``db_file = scenes.db`` will automatically create the database file ``/<work_dir>/scenes.db``.
-``scene_dir`` needs to be provided as full path to an existing directory and will be searched recursively for any Sentinel-1 scenes using the regex pattern ``'^S1[AB].*(SAFE|zip)$'``.
+``scene_dir`` needs to be provided as full path to an existing directory and will be searched recursively for any Sentinel-1
+scenes using the regular expression ``'^S1[AB].*(SAFE|zip)$'``.
 
 - search option II: **stac_catalog** & **stac_collections**
 
@@ -149,8 +150,11 @@ Supported options:
    + sg: sigma-gamma ratio: gamma0 RTC / sigma0 ellipsoidal (if ``measurement = sigma``)
 
  + wm: wind-modeled backscatter extracted from a Sentinel-1 OCN (ocean) product.
-   The variable `owiNrcsCmod` is used.
-   The OCN products and corresponding Level-1 products must be searchable in the same way.
+   The sub-product `owiNrcsCmod` is extracted, which is Ocean Wind (OWI) Normalised
+   Radar Cross Section (NRCS) predicted using a CMOD model and ECMWF wind model data.
+   For each OCN product, a Level-1 counterpart (SLC/GRD) exists.
+   The OCN products and corresponding Level-1 products must be searchable in the same way
+   via the two search options described above.
    If a sigma naught output layer exists (via ``measurement = sigma`` or `annotation` layer `ratio`),
    a co-polarization wind normalization ratio VRT is created by dividing the measurement by the
    wind-modeled backscatter.

--- a/docs/general/usage.rst
+++ b/docs/general/usage.rst
@@ -149,7 +149,7 @@ Supported options:
    + gs: gamma-sigma ratio: sigma0 RTC / gamma0 RTC (if ``measurement = gamma``)
    + sg: sigma-gamma ratio: gamma0 RTC / sigma0 ellipsoidal (if ``measurement = sigma``)
 
- + wm: wind-modeled backscatter extracted from a Sentinel-1 OCN (ocean) product.
+ + wm: wind-modelled backscatter extracted from a Sentinel-1 OCN (ocean) product.
    The sub-product `owiNrcsCmod` is extracted, which is Ocean Wind (OWI) Normalised
    Radar Cross Section (NRCS) predicted using a CMOD model and ECMWF wind model data.
    For each OCN product, a Level-1 counterpart (SLC/GRD) exists.
@@ -157,7 +157,7 @@ Supported options:
    via the two search options described above.
    If a sigma naught output layer exists (via ``measurement = sigma`` or `annotation` layer `ratio`),
    a co-polarization wind normalization ratio VRT is created by dividing the measurement by the
-   wind-modeled backscatter.
+   wind-modelled backscatter.
 
 Use one of the following to create no annotation layer:
 


### PR DESCRIPTION
This adds a new annotation layer 'wind-modeled backscatter' (suffix wm). Dividing a co-polarization sigma naught measurement in linear scaling by this new layer gives a wind-normalized image (VRT with suffix wn). This new layer does not represent a physical measurement and is intended for visualization only.

![Picture1](https://github.com/SAR-ARD/S1_NRB/assets/18419439/5e5cd50c-7aad-4fcf-8bea-8e890ab71990)

---
**NOTE**

This PR depends on recent pyroSAR changes in https://github.com/johntruckenbrodt/pyroSAR/pull/256 and https://github.com/johntruckenbrodt/pyroSAR/pull/257 so a new version needs to be released prior to merging the PR.

---