### PR TITLE
[snap.process] skip GRD buffering if list is empty

### DIFF
--- a/S1_NRB/snap.py
+++ b/S1_NRB/snap.py
@@ -187,6 +187,9 @@ def grd_buffer(src, dst, workflow, neighbors, buffer=100, gpt_args=None):
     -------
 
     """
+    if len(neighbors) == 0:
+        raise RuntimeError("the list of 'neighbors' is empty")
+    
     scenes = identify_many([src] + neighbors, sortkey='start')
     wf = parse_recipe('blank')
     ############################################
@@ -596,7 +599,8 @@ def process(scene, outdir, measurement, spacing, kml, dem,
         (only applies to GRD) an optional list of neighboring scenes to add
         a buffer around the main scene using function :func:`grd_buffer`.
         If GRDs are processed compeletely independently, gaps are introduced
-        due to a missing overlap.
+        due to a missing overlap. If `neighbors` is None or an empty list,
+        buffering is skipped.
     gpt_args: list[str] or None
         a list of additional arguments to be passed to the gpt call
         

--- a/S1_NRB/snap.py
+++ b/S1_NRB/snap.py
@@ -658,7 +658,7 @@ def process(scene, outdir, measurement, spacing, kml, dem,
             output_beta0=apply_rtc, gpt_args=gpt_args)
     ############################################################################
     # GRD buffering
-    if neighbors is not None:
+    if neighbors is not None and len(neighbors) > 0:
         # general preprocessing of neighboring scenes
         out_pre_neighbors = []
         for item in neighbors:


### PR DESCRIPTION
When processing Stripmap scenes, the list of neighboring scenes can be empty.