### PR TITLE
do not look for source metadata files if copying is not user-configured

### DIFF
--- a/S1_NRB/metadata/stac.py
+++ b/S1_NRB/metadata/stac.py
@@ -205,6 +205,8 @@ def _asset_add_orig_src(metadir, uid, item):
                 'rfi': 'Radio Frequency Interference metadata'}
     
     root_dir = os.path.join(metadir, uid)
+    if not os.path.isdir(root_dir):
+        return
     file_list = finder(target=root_dir, matchlist=['*.safe', '*.xml'], foldermode=0)
     if len(file_list) > 0:
         for file in file_list:

--- a/S1_NRB/metadata/xml.py
+++ b/S1_NRB/metadata/xml.py
@@ -86,18 +86,20 @@ def source_xml(meta, target, nsmap, ard_ns, exist_ok=False):
                                             attrib={_nsc('xlink:href', nsmap): scene})
         requestMessage = etree.SubElement(serviceReference, _nsc('ows:RequestMessage', nsmap))
         
-        org_src_files = finder(target=os.path.join(metadir, uid), matchlist=['*.safe', '*.xml'], foldermode=0)
-        if len(org_src_files) > 0:
-            for file in org_src_files:
-                href = './' + os.path.relpath(file, metadir).replace('\\', '/')
-                product = etree.SubElement(earthObservationResult, _nsc('eop:product', nsmap))
-                productInformation = etree.SubElement(product, _nsc('_:ProductInformation', nsmap, ard_ns=ard_ns))
-                fileName = etree.SubElement(productInformation, _nsc('eop:fileName', nsmap))
-                serviceReference = etree.SubElement(fileName, _nsc('ows:ServiceReference', nsmap),
-                                                    attrib={_nsc('xlink:href', nsmap): href})
-                requestMessage = etree.SubElement(serviceReference, _nsc('ows:RequestMessage', nsmap))
-                dataFormat = etree.SubElement(productInformation, _nsc('_:dataFormat', nsmap, ard_ns=ard_ns))
-                dataFormat.text = 'XML'
+        org_src_files_dir = os.path.join(metadir, uid)
+        if os.path.isdir(org_src_files_dir):
+            org_src_files = finder(target=org_src_files_dir, matchlist=['*.safe', '*.xml'], foldermode=0)
+            if len(org_src_files) > 0:
+                for file in org_src_files:
+                    href = './' + os.path.relpath(file, metadir).replace('\\', '/')
+                    product = etree.SubElement(earthObservationResult, _nsc('eop:product', nsmap))
+                    productInformation = etree.SubElement(product, _nsc('_:ProductInformation', nsmap, ard_ns=ard_ns))
+                    fileName = etree.SubElement(productInformation, _nsc('eop:fileName', nsmap))
+                    serviceReference = etree.SubElement(fileName, _nsc('ows:ServiceReference', nsmap),
+                                                        attrib={_nsc('xlink:href', nsmap): href})
+                    requestMessage = etree.SubElement(serviceReference, _nsc('ows:RequestMessage', nsmap))
+                    dataFormat = etree.SubElement(productInformation, _nsc('_:dataFormat', nsmap, ard_ns=ard_ns))
+                    dataFormat.text = 'XML'
         ################################################################################################################
         metaDataProperty = etree.SubElement(root, _nsc('eop:metaDataProperty', nsmap))
         earthObservationMetaData = etree.SubElement(metaDataProperty, _nsc('_:EarthObservationMetaData', nsmap,


### PR DESCRIPTION
In case the configuration is set to `copy_original = False`, the subdirectories for the original source metadata will not exist and can therefore not be searched for files to add as assets to the top-level metadata files.