### PR TITLE
change EW spacing from 20 to 40 m

### DIFF
--- a/S1_NRB/ancillary.py
+++ b/S1_NRB/ancillary.py
@@ -161,8 +161,6 @@ def check_spacing(spacing):
     """
     if 109800 % spacing != 0:
         raise RuntimeError(f'target spacing of {spacing} m does not align with MGRS tile size of 109800 m.')
-    if 9780 % spacing != 0:
-        raise RuntimeError(f'target spacing of {spacing} m does not align with MGRS tile overlap of 9780 m.')
 
 
 def generate_unique_id(encoded_str):

--- a/S1_NRB/config.py
+++ b/S1_NRB/config.py
@@ -291,7 +291,7 @@ def snap_conf(config):
     """
     return {'spacing': {'IW': 10,
                         'SM': 10,
-                        'EW': 20}[config['acq_mode']],
+                        'EW': 40}[config['acq_mode']],
             'allow_res_osv': True,
             'dem_resampling_method': 'BILINEAR_INTERPOLATION',
             'img_resampling_method': 'BILINEAR_INTERPOLATION',


### PR DESCRIPTION
EW is currently only acquired in GRDM mode with a 40 m spacing and approx. 90 m resolution. This should be relected in the ARD pixel spacing.