### PR TITLE
geometry buffering for minimum overlap

### DIFF
--- a/S1_NRB/ancillary.py
+++ b/S1_NRB/ancillary.py
@@ -446,12 +446,12 @@ def buffer_min_overlap(geom1, geom2, percent=1):
 
     Parameters
     ----------
-    geom1: Vector
+    geom1: spatialist.vector.Vector
         the geometry to be buffered
-    geom2: Vector
+    geom2: spatialist.vector.Vector
         the reference geometry to intersect with
-    percent: int
-        the minimum overlap as percent of `geom1`
+    percent: int or float
+        the minimum overlap in percent of `geom1`
 
     Returns
     -------

--- a/S1_NRB/ancillary.py
+++ b/S1_NRB/ancillary.py
@@ -7,6 +7,7 @@ from lxml import etree
 from datetime import datetime, timedelta
 from osgeo import gdal
 import spatialist
+from spatialist.vector import bbox, intersect
 import pyroSAR
 from pyroSAR import examine, identify_many
 import S1_NRB
@@ -43,7 +44,6 @@ def check_acquisition_completeness(scenes, archive):
     """
     messages = []
     for scene in scenes:
-        print(scene.scene)
         slice = scene.meta['sliceNumber']
         n_slices = scene.meta['totalSlices']
         groupsize = 3
@@ -435,3 +435,46 @@ def vrt_add_overviews(vrt, overviews, resampling='AVERAGE'):
     ovr.attrib['resampling'] = resampling.lower()
     etree.indent(root)
     tree.write(vrt, pretty_print=True, xml_declaration=False, encoding='utf-8')
+
+
+def buffer_min_overlap(geom1, geom2, percent=1):
+    """
+    Buffer a geometry to a minimum overlap with a second geometry.
+    The geometry is iteratively buffered until the minimum overlap is reached.
+    If the overlap of the input geometries is already larger than the defined
+    threshold, a copy of the original geometry is returned.
+
+    Parameters
+    ----------
+    geom1: Vector
+        the geometry to be buffered
+    geom2: Vector
+        the reference geometry to intersect with
+    percent: int
+        the minimum overlap as percent of `geom1`
+
+    Returns
+    -------
+
+    """
+    geom2_area = geom2.getArea()
+    ext = geom1.extent
+    ext2 = ext.copy()
+    xdist = ext['xmax'] - ext['xmin']
+    ydist = ext['ymax'] - ext['ymin']
+    buffer = 0
+    overlap = 0
+    while overlap < percent:
+        xbuf = xdist * buffer / 100 / 2
+        ybuf = ydist * buffer / 100 / 2
+        ext2['xmin'] = ext['xmin'] - xbuf
+        ext2['xmax'] = ext['xmax'] + xbuf
+        ext2['ymin'] = ext['ymin'] - ybuf
+        ext2['ymax'] = ext['ymax'] + ybuf
+        with bbox(ext2, 4326) as geom3:
+            ext3 = geom3.extent
+            with intersect(geom2, geom3) as inter:
+                inter_area = inter.getArea()
+                overlap = inter_area / geom2_area * 100
+        buffer += 1
+    return bbox(ext3, 4326)

--- a/S1_NRB/processor.py
+++ b/S1_NRB/processor.py
@@ -119,18 +119,21 @@ def main(config_file, section_name='PROCESSING', debug=False, **kwargs):
     
     if len(selection) == 0:
         msg = "No scenes could be found for the following search query:\n" \
-              " sensor:    '{sensor}'\n" \
-              " product:   '{product}'\n" \
-              " acq. mode: '{acq_mode}'\n" \
-              " mindate:   '{mindate}'\n" \
-              " maxdate:   '{maxdate}'\n" \
-              " datatake:  '{datatake}'\n"
+              " sensor:      '{sensor}'\n" \
+              " product:     '{product}'\n" \
+              " acq. mode:   '{acq_mode}'\n" \
+              " mindate:     '{mindate}'\n" \
+              " maxdate:     '{maxdate}'\n" \
+              " date_strict: '{date_strict}'\n" \
+              " datatake:    '{datatake}'\n"
         print(msg.format(sensor=config['sensor'], acq_mode=config['acq_mode'],
                          product=config['product'], mindate=config['mindate'],
-                         maxdate=config['maxdate'], scene_dir=config['scene_dir'],
+                         maxdate=config['maxdate'], date_strict=config['date_strict'],
                          datatake=config['datatake']))
         archive.close()
         return
+    print('found the following scene(s):')
+    print('\n'.join(selection))
     scenes = identify_many(selection, sortkey='start')
     anc.check_acquisition_completeness(scenes=scenes, archive=archive)
     

--- a/S1_NRB/snap.py
+++ b/S1_NRB/snap.py
@@ -760,7 +760,8 @@ def process(scene, outdir, measurement, spacing, kml, dem,
                 bands1.append('simulatedImage')
             if 'lookDirection' in export_extra:
                 bands0.append('lookDirection')
-            geo(out_mli, out_rtc, out_gsr, out_sgr, dst=out_geo, workflow=out_geo_wf,
+            geo(out_mli, out_rtc, out_gsr, out_sgr,
+                dst=out_geo, workflow=out_geo_wf,
                 spacing=spacing, crs=epsg, geometry=ext,
                 export_extra=export_extra,
                 standard_grid_origin_x=align_x,

--- a/S1_NRB/snap.py
+++ b/S1_NRB/snap.py
@@ -1,6 +1,5 @@
 import os
 import re
-import itertools
 import shutil
 from math import ceil
 import copy
@@ -11,16 +10,14 @@ from osgeo import gdal, gdalconst
 from scipy.interpolate import griddata
 from datetime import datetime
 from dateutil.parser import parse as dateparse
-from spatialist import bbox, Raster
+from spatialist import Raster
 from spatialist.envi import HDRobject
 from spatialist.ancillary import finder
-from spatialist.auxil import utm_autodetect
 from pyroSAR import identify, identify_many
 from pyroSAR.snap.auxil import gpt, parse_recipe, parse_node, \
     orb_parametrize, mli_parametrize, geo_parametrize, \
     sub_parametrize, erode_edges
-from S1_NRB.tile_extraction import tile_from_aoi, aoi_from_tile
-from S1_NRB.ancillary import get_max_ext
+from S1_NRB.tile_extraction import aoi_from_scene
 
 
 def mli(src, dst, workflow, spacing=None, rlks=None, azlks=None, gpt_args=None):
@@ -780,34 +777,14 @@ def process(scene, outdir, measurement, spacing, kml, dem,
             if wf != wf_dst:
                 shutil.copyfile(src=wf, dst=wf_dst)
     
-    if utm_multi:
-        print('### determining UTM zone overlaps')
-        with id.geometry() as geom:
-            tiles = tile_from_aoi(vector=geom, kml=kml)
-        for zone, group in itertools.groupby(tiles, lambda x: x[:2]):
-            group = list(group)
-            geometries = [aoi_from_tile(kml=kml, tile=x) for x in group]
-            epsg = geometries[0].getProjection(type='epsg')
-            print(f'### geocoding to EPSG:{epsg}')
-            ext = get_max_ext(geometries=geometries)
-            align_x = ext['xmin']
-            align_y = ext['ymax']
-            del geometries
-            with bbox(coordinates=ext, crs=epsg) as geom:
-                geom.reproject(projection=4326)
-                ext = geom.extent
-            run()
-    else:
-        with id.bbox() as geom:
-            ext = geom.extent
-            epsg = utm_autodetect(geom, 'epsg')
-            print(f'### geocoding to EPSG:{epsg}')
-            tiles = tile_from_aoi(vector=geom, kml=kml, epsg=epsg,
-                                  return_geometries=True, strict=False)
-            ext_utm = tiles[0].extent
-            del tiles
-            align_x = ext_utm['xmin']
-            align_y = ext_utm['ymax']
+    print('### determining UTM zone overlaps')
+    aois = aoi_from_scene(scene=id, kml=kml, multi=utm_multi)
+    for aoi in aois:
+        ext = aoi['extent']
+        epsg = aoi['epsg']
+        align_x = aoi['align_x']
+        align_y = aoi['align_y']
+        print(f'### geocoding to EPSG:{epsg}')
         run()
     if cleanup:
         if id.product == 'GRD':

--- a/S1_NRB/snap.py
+++ b/S1_NRB/snap.py
@@ -553,8 +553,8 @@ def process(scene, outdir, measurement, spacing, kml, dem,
     measurement: {'sigma', 'gamma'}
         the backscatter measurement convention:
         
-        - gamma: RTC gamma nought (gamma^0_T)
-        - sigma: ellipsoidal sigmal nought (sigma^0_E)
+        - gamma: RTC gamma nought (:math:`\gamma^0_T`)
+        - sigma: ellipsoidal sigmal nought (:math:`\sigma^0_E`)
     spacing: int or float
         The output pixel spacing in meters.
     kml: str
@@ -576,8 +576,8 @@ def process(scene, outdir, measurement, spacing, kml, dem,
         Options:
         
          - DEM
-         - gammaSigmaRatio: sigma^0_T / gamma^0_T
-         - sigmaGammaRatio: gamma^0_T / sigma^0_E
+         - gammaSigmaRatio: :math:`\sigma^0_T / \gamma^0_T`
+         - sigmaGammaRatio: :math:`\gamma^0_T / \sigma^0_E`
          - incidenceAngleFromEllipsoid
          - layoverShadowMask
          - localIncidenceAngle

--- a/S1_NRB/tile_extraction.py
+++ b/S1_NRB/tile_extraction.py
@@ -162,7 +162,7 @@ def description2dict(description):
     return attrib
 
 
-def aoi_from_scene(scene, kml, multi=True):
+def aoi_from_scene(scene, kml, multi=True, percent=1):
     """
     Get processing AOIs for a SAR scene. The MGRS grid requires a SAR scene to be geocoded to multiple UTM zones
     depending on the overlapping MGRS tiles and their projection. This function returns the following for each
@@ -172,6 +172,9 @@ def aoi_from_scene(scene, kml, multi=True):
     - the EPSG code of the UTM zone (key `epsg`)
     - the Easting coordinate for pixel alignment (key `align_x`)
     - the Northing coordinate for pixel alignment (key `align_y`)
+    
+    A minimum overlap of the AOIs with the SAR scene is ensured by buffering the AOIs if necessary.
+    The minimum overlap can be controlled with parameter `percent`.
     
     Parameters
     ----------
@@ -183,6 +186,9 @@ def aoi_from_scene(scene, kml, multi=True):
         split into multiple AOIs per overlapping UTM zone or just one AOI covering the whole scene.
         In the latter case the best matching UTM zone is auto-detected
         (using function :func:`spatialist.auxil.utm_autodetect`).
+    percent: int or float
+        the minimum overlap in percent of each AOI with the SAR scene.
+        See function :func:`S1_NRB.ancillary.buffer_min_overlap`.
 
     Returns
     -------
@@ -212,7 +218,8 @@ def aoi_from_scene(scene, kml, multi=True):
             # ensure a minimum overlap between AOI and pre-processed scene
             with bbox(ext, 4326) as geom1:
                 with scene.geometry() as geom2:
-                    with buffer_min_overlap(geom1=geom1, geom2=geom2) as buffered:
+                    with buffer_min_overlap(geom1=geom1, geom2=geom2,
+                                            percent=percent) as buffered:
                         ext = buffered.extent
             out.append({'extent': ext, 'epsg': epsg,
                         'align_x': align_x, 'align_y': align_y})

--- a/S1_NRB/tile_extraction.py
+++ b/S1_NRB/tile_extraction.py
@@ -1,6 +1,9 @@
 import re
+import itertools
 from lxml import html
 from spatialist.vector import Vector, wkt2vector, bbox
+from spatialist.auxil import utm_autodetect
+from S1_NRB.ancillary import get_max_ext
 
 
 def tile_from_aoi(vector, kml, epsg=None, strict=True, return_geometries=False, tilenames=None):
@@ -157,3 +160,70 @@ def description2dict(description):
     attrib = dict(zip(attrib[0::2], attrib[1::2]))
     attrib['EPSG'] = int(attrib['EPSG'])
     return attrib
+
+
+def aoi_from_scene(scene, kml, multi=True):
+    """
+    Get processing AOIs for a SAR scene. The MGRS grid requires a SAR scene to be geocoded to multiple UTM zones
+    depending on the overlapping MGRS tiles and their projection. This function returns the following for each
+    UTM zone group:
+    
+    - the extent in WGS84 coordinates (key `extent`)
+    - the EPSG code of the UTM zone (key `epsg`)
+    - the Easting coordinate for pixel alignment (key `align_x`)
+    - the Northing coordinate for pixel alignment (key `align_y`)
+    
+    Parameters
+    ----------
+    scene: pyroSAR.drivers.ID
+        the SAR scene object
+    kml: str
+        Path to the Sentinel-2 tiling grid KML file.
+    multi: bool
+        split into multiple AOIs per overlapping UTM zone or just one AOI covering the whole scene.
+        In the latter case the best matching UTM zone is auto-detected
+        (using function :func:`spatialist.auxil.utm_autodetect`).
+
+    Returns
+    -------
+    list[dict]
+        a list of dictionaries with keys `extent`, `epsg`, `align_x`, `align_y`
+    """
+    out = []
+    if multi:
+        # extract all overlapping tiles
+        with scene.geometry() as geom:
+            tiles = tile_from_aoi(vector=geom, kml=kml, return_geometries=True)
+        # group tiles by UTM zone
+        for zone, group in itertools.groupby(tiles, lambda x: x.mgrs[:2]):
+            geometries = list(group)
+            # get UTM EPSG code
+            epsg = geometries[0].getProjection(type='epsg')
+            # get maximum extent of tile group
+            ext = get_max_ext(geometries=geometries)
+            # determine corner coordinate for alignment
+            align_x = ext['xmin']
+            align_y = ext['ymax']
+            del geometries
+            # convert extent to EPSG:4326
+            with bbox(coordinates=ext, crs=epsg) as geom:
+                geom.reproject(projection=4326)
+                ext = geom.extent
+            out.append({'extent': ext, 'epsg': epsg,
+                        'align_x': align_x, 'align_y': align_y})
+    else:
+        with scene.bbox() as geom:
+            ext = geom.extent
+            # auto-detect UTM zone
+            epsg = utm_autodetect(geom, 'epsg')
+            # get all tiles, reprojected to the target UTM zone if necessary
+            tiles = tile_from_aoi(vector=geom, kml=kml, epsg=epsg,
+                                  return_geometries=True, strict=False)
+        # determine corner coordinate for alignment
+        ext_utm = tiles[0].extent
+        align_x = ext_utm['xmin']
+        align_y = ext_utm['ymax']
+        del tiles
+        out.append({'extent': ext, 'epsg': epsg,
+                    'align_x': align_x, 'align_y': align_y})
+    return out

--- a/S1_NRB/tile_extraction.py
+++ b/S1_NRB/tile_extraction.py
@@ -3,7 +3,7 @@ import itertools
 from lxml import html
 from spatialist.vector import Vector, wkt2vector, bbox
 from spatialist.auxil import utm_autodetect
-from S1_NRB.ancillary import get_max_ext
+from S1_NRB.ancillary import get_max_ext, buffer_min_overlap
 
 
 def tile_from_aoi(vector, kml, epsg=None, strict=True, return_geometries=False, tilenames=None):
@@ -209,6 +209,11 @@ def aoi_from_scene(scene, kml, multi=True):
             with bbox(coordinates=ext, crs=epsg) as geom:
                 geom.reproject(projection=4326)
                 ext = geom.extent
+            # ensure a minimum overlap between AOI and pre-processed scene
+            with bbox(ext, 4326) as geom1:
+                with scene.geometry() as geom2:
+                    with buffer_min_overlap(geom1=geom1, geom2=geom2) as buffered:
+                        ext = buffered.extent
             out.append({'extent': ext, 'epsg': epsg,
                         'align_x': align_x, 'align_y': align_y})
     else:

--- a/docs/about/abbreviations.rst
+++ b/docs/about/abbreviations.rst
@@ -7,6 +7,8 @@ Abbreviations
 
    * - Abbreviation
      - Meaning
+   * - AOI
+     - Area Of Interest
    * - ARD
      - Analysis Ready Data
    * - ASF

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -150,6 +150,7 @@ Ancillary Functions
     .. autosummary::
         :nosignatures:
 
+        buffer_min_overlap
         check_acquisition_completeness
         check_scene_consistency
         check_spacing

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -134,6 +134,7 @@ Tile Extraction
     .. autosummary::
         :nosignatures:
 
+        aoi_from_scene
         aoi_from_tile
         description2dict
         tile_from_aoi

--- a/docs/general/enl.rst
+++ b/docs/general/enl.rst
@@ -40,7 +40,7 @@ the resulting array is shown in Figure 1.
 
 Comparison between GRDH and NRB
 -------------------------------
-[1] provides estimates of ENL for different Sentinel-1 products (average over all swaths), e.g. ENL of 4.4 for GRDH in
+:footcite:`cls_2016` provides estimates of ENL for different Sentinel-1 products (average over all swaths), e.g. ENL of 4.4 for GRDH in
 IW mode, and a description of the estimation process in section D1. The following shows a simple comparison between the
 GRDH product:
 

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -13,7 +13,7 @@ dependencies:
   - pystac>=1.8.0
   - pystac-client
   - scipy
-  - pyroSAR>=0.22.0
+  - pyroSAR>=0.22.1
   - spatialist>=0.12.0
   - s1etad>=0.5.3
   - s1etad_tools>=0.8.1

--- a/environment.yaml
+++ b/environment.yaml
@@ -13,7 +13,7 @@ dependencies:
   - pystac>=1.8.0
   - pystac-client
   - scipy
-  - pyroSAR>=0.22.0
+  - pyroSAR>=0.22.1
   - spatialist>=0.12.0
   - s1etad>=0.5.3
   - s1etad_tools>=0.8.1

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
                       'click>=7.1.0',
                       'lxml',
                       'pystac>=1.8.0',
-                      'pyroSAR>=0.22.0',
+                      'pyroSAR>=0.22.1',
                       'spatialist>=0.12.0',
                       'scipy',
                       's1etad>=0.5.3',


### PR DESCRIPTION
For geocoding, the processor first selects all MGRS tiles in a particular UTM zone with a SAR scene. The bounding box of the selected tiles is then used as subset for geocoding only parts of the scene. It can happen that the selected subset  is too small and SNAP trows an error. This is more likely to occur near the poles where up to nine different UTM zones were observed to overlap with one EW scene.
With this PR, a new function is introduced to buffer the subset geometry to have a minimum overlap of 1% with the scene's footprint to ensure a sufficiently large subset for geocoding.
This is handled by functions `ancillary.buffer_min_overlap`and `tile_extraction.aoi_from_scene`. The latter was outsourced from code in `snap.process`.
