### PR TITLE
STACArchive file path handling

### DIFF
--- a/S1_NRB/archive.py
+++ b/S1_NRB/archive.py
@@ -230,8 +230,11 @@ class STACArchive(object):
             ref = assets[list(assets.keys())[0]]
             href = ref.href
             path = href[:re.search(r'\.SAFE', href).end()]
-            if check_exist:
-                if not Path(path).exists():
+            path = re.sub('^file://', '', path)
+            if Path(path).exists():
+                path = os.path.realpath(path)
+            else:
+                if check_exist:
                     raise RuntimeError('scene does not exist locally:', path)
             out.append(path)
         out = self._filter_duplicates(out)

--- a/S1_NRB/archive.py
+++ b/S1_NRB/archive.py
@@ -79,7 +79,7 @@ class STACArchive(object):
         i = 1
         while True:
             try:
-                self.catalog = Client.open(self.url, ignore_conformance=True)
+                self.catalog = Client.open(self.url)
                 # print('catalog opened successfully')
                 break
             except pystac_client.exceptions.APIError:


### PR DESCRIPTION
This fixes two minor bugs when handling scene paths returned from `STACArchive.select`:
- handling of file URLs with `file://` prefix
- handling of paths with `/./` component