### PR TITLE
Use the official Continuum Docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM conda/miniconda3 as snap
+FROM continuumio/miniconda3 as snap
 
 USER root
 


### PR DESCRIPTION
The `conda/miniconda3` Docker image has not been updated in five years, and it looks like it has finally broken.

(The Debian version it uses was archived by the Debian project recently, and some of the download links now fail.)

Luckily the official Continuum image seems to work as a drop-in replacement.