### PR TITLE
strip line breaks from all parameters passed via the command line

### DIFF
--- a/S1_NRB/config.py
+++ b/S1_NRB/config.py
@@ -74,7 +74,7 @@ def get_config(config_file, proc_section='PROCESSING', **kwargs):
     
     # override config file parameters
     for k, v in kwargs.items():
-        proc_sec[k] = v
+        proc_sec[k] = v.strip()
     
     # set some defaults
     if 'etad' not in proc_sec.keys():
@@ -123,7 +123,7 @@ def get_config(config_file, proc_section='PROCESSING', **kwargs):
         if k == 'mindate':
             v = proc_sec.get_datetime(k)
         if k == 'maxdate':
-            date_short = re.search('^[0-9-]{10}$', v.strip()) is not None
+            date_short = re.search('^[0-9-]{10}$', v) is not None
             v = proc_sec.get_datetime(k)
             if date_short:
                 v += timedelta(days=1, microseconds=-1)


### PR DESCRIPTION
Parameters passed vial the command line contain a line break at the end of the string. This was recently fixed for date strings in https://github.com/SAR-ARD/S1_NRB/commit/12c8e33f7a34757317f8303c4d4f3d39ca5abc74. Now this is done more universally for all strings.