### PR TITLE
[config] corrected list of allowed modes

### DIFF
--- a/S1_NRB/config.py
+++ b/S1_NRB/config.py
@@ -238,7 +238,7 @@ def _parse_modes(s):
     """Custom converter for configparser:
     https://docs.python.org/3/library/configparser.html#customizing-parser-behaviour"""
     mode_list = _parse_list(s)
-    allowed = ['sar', 'ard', 'orb']
+    allowed = ['sar', 'nrb', 'orb']
     for mode in mode_list:
         if mode not in allowed:
             msg = "Parameter 'annotation': Error while parsing to list; " \


### PR DESCRIPTION
Accepted modes are `sar`, `nrb` and `orb`. The `config` module now correctly check for them.