### PR TITLE
Update metadata links

### DIFF
--- a/S1_NRB/metadata/extract.py
+++ b/S1_NRB/metadata/extract.py
@@ -146,8 +146,8 @@ def meta_dict(config, target, src_ids, sar_dir, proc_time, start, stop, compress
     meta['prod']['geoCorrAccuracyNorthernBias'] = None
     meta['prod']['geoCorrAccuracyNorthernSTDev'] = None
     meta['prod']['geoCorrAccuracyReference'] = 'https://s1-nrb.readthedocs.io/en/v{}/general/geoaccuracy.html' \
-                                               ''.format(S1_NRB.__version__)
-    meta['prod']['geoCorrAccuracyType'] = 'slant-range'
+                                               ''.format(S1_NRB.__version__) if geo_corr_accuracy is not None else None
+    meta['prod']['geoCorrAccuracyType'] = 'slant-range' if geo_corr_accuracy is not None else None
     meta['prod']['geoCorrAccuracy_rRMSE'] = geo_corr_accuracy
     meta['prod']['geoCorrAlgorithm'] = 'https://sentinel.esa.int/documents/247904/1653442/' \
                                        'Guide-to-Sentinel-1-Geocoding.pdf'

--- a/S1_NRB/metadata/extract.py
+++ b/S1_NRB/metadata/extract.py
@@ -256,7 +256,7 @@ def meta_dict(config, target, src_ids, sar_dir, proc_time, start, stop, compress
         
         # (sorted alphabetically)
         meta['source'][uid] = {}
-        meta['source'][uid]['access'] = 'https://scihub.copernicus.eu'
+        meta['source'][uid]['access'] = 'https://dataspace.copernicus.eu'
         meta['source'][uid]['acquisitionType'] = 'NOMINAL'
         meta['source'][uid]['ascendingNodeDate'] = _read_manifest('.//s1:ascendingNodeTime')
         meta['source'][uid]['azimuthLookBandwidth'] = az_look_bandwidth


### PR DESCRIPTION
Two minor changes: 
- Update link to source product access to `https://dataspace.copernicus.eu`
- Only include link to Geolocation Accuracy reference only if actually computed