### PR TITLE
[metadata.xml.product_xml] add geo acc. reference only if performed

### DIFF
--- a/S1_NRB/metadata/xml.py
+++ b/S1_NRB/metadata/xml.py
@@ -343,7 +343,7 @@ def product_xml(meta, target, assets, nsmap, ard_ns, exist_ok=False):
             
             sampleType = etree.SubElement(productInformation, _nsc('_:sampleType', nsmap, ard_ns=ard_ns),
                                           attrib={'uom': 'unitless' if ASSET_MAP[key]['unit'] is None else
-                                                         ASSET_MAP[key]['unit']})
+                                          ASSET_MAP[key]['unit']})
             sampleType.text = ASSET_MAP[key]['type']
             
             if key in ['-dm.tif', '-id.tif']:
@@ -432,13 +432,14 @@ def product_xml(meta, target, assets, nsmap, ard_ns, exist_ok=False):
         noiseRemovalAlgorithm = etree.SubElement(processingInformation,
                                                  _nsc('_:noiseRemovalAlgorithm', nsmap, ard_ns=ard_ns),
                                                  attrib={_nsc('xlink:href', nsmap):
-                                                         meta['prod']['noiseRemovalAlgorithm']})
+                                                             meta['prod']['noiseRemovalAlgorithm']})
     if meta['prod']['RTCAlgorithm'] is not None:
         rtcAlgorithm = etree.SubElement(processingInformation, _nsc('_:RTCAlgorithm', nsmap, ard_ns=ard_ns),
                                         attrib={_nsc('xlink:href', nsmap): meta['prod']['RTCAlgorithm']})
     if meta['prod']['windNormBackscatterMeasurement'] is not None:
         windNormBackscatterMeasurement = etree.SubElement(processingInformation,
-                                                          _nsc('_:windNormBackscatterMeasurement', nsmap, ard_ns=ard_ns))
+                                                          _nsc('_:windNormBackscatterMeasurement',
+                                                               nsmap, ard_ns=ard_ns))
         windNormBackscatterMeasurement.text = meta['prod']['windNormBackscatterMeasurement']
         windNormBackscatterConvention = etree.SubElement(processingInformation,
                                                          _nsc('_:windNormBackscatterConvention', nsmap, ard_ns=ard_ns))
@@ -450,7 +451,8 @@ def product_xml(meta, target, assets, nsmap, ard_ns, exist_ok=False):
         
         windNormReferenceModel = etree.SubElement(processingInformation, _nsc('_:windNormReferenceModel', nsmap,
                                                                               ard_ns=ard_ns),
-                                                  attrib={_nsc('xlink:href', nsmap): meta['prod']['windNormReferenceModel']})
+                                                  attrib={_nsc('xlink:href', nsmap):
+                                                              meta['prod']['windNormReferenceModel']})
         windNormReferenceSpeed = etree.SubElement(processingInformation,
                                                   _nsc('_:windNormReferenceSpeed', nsmap, ard_ns=ard_ns),
                                                   attrib={'uom': 'm_s'})
@@ -532,9 +534,10 @@ def product_xml(meta, target, assets, nsmap, ard_ns, exist_ok=False):
                                              attrib={'uom': 'm'})
     geoCorrAccuracy_rRMSE.text = str(meta['prod']['geoCorrAccuracy_rRMSE'])
     geoacc_ref = meta['prod']['geoCorrAccuracyReference']
-    geoCorrAccuracyReference = etree.SubElement(earthObservationMetaData,
-                                                _nsc('_:geoCorrAccuracyReference', nsmap, ard_ns=ard_ns),
-                                                attrib={_nsc('xlink:href', nsmap): geoacc_ref})
+    if geoacc_ref is not None:
+        geoCorrAccuracyReference = etree.SubElement(earthObservationMetaData,
+                                                    _nsc('_:geoCorrAccuracyReference', nsmap, ard_ns=ard_ns),
+                                                    attrib={_nsc('xlink:href', nsmap): geoacc_ref})
     numLines = etree.SubElement(earthObservationMetaData, _nsc('_:numLines', nsmap, ard_ns=ard_ns))
     numLines.text = meta['prod']['numLines']
     numPixelsPerLine = etree.SubElement(earthObservationMetaData, _nsc('_:numPixelsPerLine', nsmap, ard_ns=ard_ns))


### PR DESCRIPTION
Fixes the following error:
```python
Traceback (most recent call last):
  File "bin/s1_nrb", line 33, in <module>
    sys.exit(load_entry_point('S1-NRB', 'console_scripts', 's1_nrb')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "S1_NRB/cli.py", line 60, in cli
    S1_NRB.process(config_file=config_file, section_name=section, debug=debug, **extra)
  File "S1_NRB/processor.py", line 343, in main
    msg = ard.format(config=config, product_type=product_type, scenes=scenes_sub_fnames,
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "S1_NRB/ard.py", line 400, in format
    xml.parse(meta=meta, target=ard_dir, assets=ard_assets, exist_ok=True)
  File "S1_NRB/metadata/xml.py", line 37, in parse
    product_xml(meta=meta, target=target, assets=assets, nsmap=nsmap, ard_ns=key,
  File "S1_NRB/metadata/xml.py", line 535, in product_xml
    geoCorrAccuracyReference = etree.SubElement(earthObservationMetaData,
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "src/lxml/etree.pyx", line 3156, in lxml.etree.SubElement
  File "src/lxml/apihelpers.pxi", line 199, in lxml.etree._makeSubElement
  File "src/lxml/apihelpers.pxi", line 194, in lxml.etree._makeSubElement
  File "src/lxml/apihelpers.pxi", line 324, in lxml.etree._initNodeAttributes
  File "src/lxml/apihelpers.pxi", line 335, in lxml.etree._addAttributeToNode
  File "src/lxml/apihelpers.pxi", line 1539, in lxml.etree._utf8
TypeError: Argument must be bytes or unicode, got 'NoneType'

```

This was most likely introduced recently with https://github.com/SAR-ARD/S1_NRB/pull/165.