### PR TITLE
avoid permission error when passing tempfile to gdalwarp

### DIFF
--- a/S1_NRB/metadata/extract.py
+++ b/S1_NRB/metadata/extract.py
@@ -799,11 +799,11 @@ def calc_wm_ref_stats(wm_ref_files, epsg, bounds, resolution=915):
     files_speed = [f for f in wm_ref_files if f.endswith('Speed.tif')]
     files_direction = [f for f in wm_ref_files if f.endswith('Direction.tif')]
     
-    ref_speed = tempfile.NamedTemporaryFile(suffix='.tif')
-    ref_direction = tempfile.NamedTemporaryFile(suffix='.tif')
+    ref_speed = tempfile.NamedTemporaryFile(suffix='.tif', delete=False).name
+    ref_direction = tempfile.NamedTemporaryFile(suffix='.tif', delete=False).name
     
     out = []
-    for src, dst in zip([files_speed, files_direction], [ref_speed.name, ref_direction.name]):
+    for src, dst in zip([files_speed, files_direction], [ref_speed, ref_direction]):
         gdalwarp(src=src, dst=dst,
                  outputBounds=bounds,
                  dstSRS=f'EPSG:{epsg}',
@@ -812,9 +812,8 @@ def calc_wm_ref_stats(wm_ref_files, epsg, bounds, resolution=915):
         with Raster(dst) as ras:
             arr = ras.array()
             out.append(round(np.nanmean(arr), 2))
+        os.remove(dst)
     
-    ref_speed.close()
-    ref_direction.close()
     return tuple(out)
 
 


### PR DESCRIPTION
In the function `extract.calc_wm_ref_stats` a `tempfile.NamedTemporaryFile` is used to create a temporary file name. However, this class does not only return a file name but an open file object. This was causing a permission error on Windows when trying to use the file name in `gdalwarp`. After this change the class is still used but the object is closed before passing the file name to `gdalwarp`. Furthermore, the file now has to be deleted manually, a job that was previously performed automatically by`tempfile.NamedTemporaryFile` upon descoping the opened file object.