### PR TITLE
[search.scene_select] compare strings with '==' instead of 'is'

### DIFF
--- a/S1_NRB/search.py
+++ b/S1_NRB/search.py
@@ -443,7 +443,7 @@ def asf_select(sensor, product, acquisition_mode, mindate, maxdate,
                     if start <= date_extract(x, 'startTime')
                     and date_extract(x, 'stopTime') <= stop]
     
-    if return_value is 'ASF':
+    if return_value == 'ASF':
         return [ASF(x) for x in features]
     out = []
     for item in features:


### PR DESCRIPTION
minor syntax change to avoid Python warning