### PR TITLE
new configuration parameter 'scene'

### DIFF
--- a/S1_NRB/ancillary.py
+++ b/S1_NRB/ancillary.py
@@ -229,6 +229,7 @@ def _log_process_config(logger, config):
     mode                {config['mode']}
     aoi_tiles           {config['aoi_tiles']}
     aoi_geometry        {config['aoi_geometry']}
+    scene               {config['scene']}
     mindate             {config['mindate'].isoformat()}
     maxdate             {config['maxdate'].isoformat()}
     date_strict         {config['date_strict']}

--- a/S1_NRB/cli.py
+++ b/S1_NRB/cli.py
@@ -33,7 +33,7 @@ def cli(ctx, config_file, section, debug, version):
     \b
     The following defaults are set:
     (processing section)
-    - annotation: dm,ei,id,lc,li,np,ratio
+    - annotation:        dm,ei,id,lc,li,np,ratio
     - dem_type:          Copernicus 30m Global DEM
     - date_strict:       True
     - etad:              False

--- a/S1_NRB/config.py
+++ b/S1_NRB/config.py
@@ -25,7 +25,7 @@ def get_keys(section):
                 'work_dir', 'scene_dir', 'sar_dir', 'tmp_dir', 'wbm_dir', 'measurement',
                 'db_file', 'kml_file', 'dem_type', 'gdal_threads', 'log_dir', 'ard_dir',
                 'etad', 'etad_dir', 'product', 'annotation', 'stac_catalog', 'stac_collections',
-                'sensor', 'date_strict', 'snap_gpt_args']
+                'sensor', 'date_strict', 'snap_gpt_args', 'scene']
     elif section == 'metadata':
         return ['format', 'copy_original', 'access_url', 'licence', 'doi', 'processing_center']
     else:

--- a/config.ini
+++ b/config.ini
@@ -15,13 +15,18 @@
 # orb: ORB generation from existing pre-processed SAR products
 mode = sar, nrb
 
+# define a single SAR scene filename instead of searching for scenes in a database
+# if this parameter is set, the 'mode' must be 'sar'
+# in case of a GRD, database search is still performed to collect neighbors
+scene =
+
 # optional definition of a geometry via tile IDs or a vector file.
 # [aoi_tiles] expects a comma-separated list of MGRS tile IDs.
 # [aoi_geometry] expects a full path to a vector file (GeoJSON, GPKG, KML or Shapefile).
 # This option identifies MGRS tile IDs that intersect with the given vector geometry.
 # [aoi_tiles] overrides [aoi_geometry].
 aoi_tiles = 32TMT, 32TNT
-aoi_geometry = None
+aoi_geometry =
 
 # Allowed date formats: anything that can be parsed by
 # https://dateutil.readthedocs.io/en/stable/parser.html#dateutil.parser.parse

--- a/docs/general/usage.rst
+++ b/docs/general/usage.rst
@@ -70,6 +70,13 @@ By defining both ``sar`` and one of the ARD modes as list, both SAR preprocessin
 
     mode = sar, nrb
 
+scene
++++++
+
+Define a single SAR scene filename instead of searching for scenes in a database.
+If this parameter is set, the 'mode' must be 'sar'.
+In case of a GRD, database search is still performed to collect neighbors.
+
 aoi_tiles & aoi_geometry
 ++++++++++++++++++++++++
 


### PR DESCRIPTION
With this, it is possible to process a single scene and skip selection from a database. If the scene is a GRD product, a database query is still performed to select neighboring acquisitions.  
This parameter can only be set when the processing mode is `sar` because ARD generation usually requires more than one scene.