### PR TITLE
STAC query optimizations

### DIFF
--- a/S1_NRB/search.py
+++ b/S1_NRB/search.py
@@ -91,7 +91,7 @@ class STACArchive(object):
     pystac_client.stac_api_io.StacApiIO
     """
     
-    def __init__(self, url, collections, timeout=20, max_retries=20):
+    def __init__(self, url, collections, timeout=60, max_retries=20):
         self.url = url
         self.timeout = timeout
         self.max_tries = max_retries

--- a/S1_NRB/search.py
+++ b/S1_NRB/search.py
@@ -82,8 +82,9 @@ class STACArchive(object):
         the catalog collection(s) to be searched
     """
     
-    def __init__(self, url, collections):
+    def __init__(self, url, collections, timeout=20):
         self.url = url
+        self.timeout = timeout
         self.max_tries = 300
         self._open_catalog()
         if isinstance(collections, str):
@@ -137,7 +138,8 @@ class STACArchive(object):
         i = 1
         while True:
             try:
-                self.catalog = Client.open(self.url)
+                self.catalog = Client.open(url=self.url,
+                                           timeout=self.timeout)
                 # print('catalog opened successfully')
                 break
             except pystac_client.exceptions.APIError:

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -11,7 +11,7 @@ dependencies:
   - lxml
   - pip
   - pystac>=1.8.0
-  - pystac-client
+  - pystac-client>=0.7.0
   - scipy
   - pyroSAR>=0.23.0
   - spatialist>=0.12.0

--- a/environment.yaml
+++ b/environment.yaml
@@ -11,7 +11,7 @@ dependencies:
   - lxml
   - pip
   - pystac>=1.8.0
-  - pystac-client
+  - pystac-client>=0.7.0
   - scipy
   - pyroSAR>=0.23.0
   - spatialist>=0.12.0

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
                       'scipy',
                       's1etad>=0.5.3',
                       's1etad_tools>=0.8.1',
-                      'pystac-client',
+                      'pystac-client>=0.7.0',
                       'numpy',
                       'asf_search',
                       'pyproj'],


### PR DESCRIPTION
This improves the STAC queries in `search.STACArchive` by
- increasing the timeout and enabling users to modify it (new argument `timeout`)
- making use of `pystac-client`'s mechanism for retries instead of the own implementation and enabling users to modify it (new argument `max_retries`)
- significantly increasing the query speed by passing parameters for spatial and temporal querying directly to `pystac_client.client.Client.search` arguments `datetime` and `bbox` instead of to the `filter` argument