### PR TITLE
bugfix - adding neighbour to list for SLC processing

### DIFF
--- a/S1_NRB/processor.py
+++ b/S1_NRB/processor.py
@@ -91,12 +91,13 @@ def main(config_file, section_name='PROCESSING', debug=False, **kwargs):
     ####################################################################################################################
     # get neighboring GRD scenes to add a buffer to the geocoded scenes
     # otherwise there will be a gap between final geocoded images.
-    neighbors = [None]
     if config['product'] == 'GRD':
         print('###### [    SAR] collecting GRD neighbors')
         neighbors = []
         for scene in scenes:
             neighbors.append(search.collect_neighbors(archive=archive, scene=scene))
+    else:
+        neighbors = [None for scene in scenes]
     ####################################################################################################################
     # OCN scene selection
     if 'wm' in config['annotation']:

--- a/S1_NRB/processor.py
+++ b/S1_NRB/processor.py
@@ -91,7 +91,7 @@ def main(config_file, section_name='PROCESSING', debug=False, **kwargs):
     ####################################################################################################################
     # get neighboring GRD scenes to add a buffer to the geocoded scenes
     # otherwise there will be a gap between final geocoded images.
-    neighbors = None
+    neighbors = [None]
     if config['product'] == 'GRD':
         print('###### [    SAR] collecting GRD neighbors')
         neighbors = []


### PR DESCRIPTION
Process not running with an SLC. Neighbors should be initiated as a list as when it is called on line 202 in the snap.geocode function; a list is expected ```neighbors=neighbors[i]```

The following error will result processing a SLC:

```
2024-03-13 00:31:05 INFO     Traceback (most recent call last):
  File "/opt/conda/envs/nrb_env/bin/s1_nrb", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/opt/conda/envs/nrb_env/lib/python3.12/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/envs/nrb_env/lib/python3.12/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/opt/conda/envs/nrb_env/lib/python3.12/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/envs/nrb_env/lib/python3.12/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/envs/nrb_env/lib/python3.12/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/envs/nrb_env/lib/python3.12/site-packages/S1_NRB/cli.py", line 60, in cli
    S1_NRB.process(config_file=config_file, section_name=section, debug=debug, **extra)
  File "/opt/conda/envs/nrb_env/lib/python3.12/site-packages/S1_NRB/processor.py", line 202, in main
    dem=fname_dem, neighbors=neighbors[i],
                             ~~~~~~~~~^^^
TypeError: 'NoneType' object is not subscriptable
```