### PR TITLE
[aoi_from_scene] fixed bug in handling scenes crossing the equator

### DIFF
--- a/S1_NRB/tile_extraction.py
+++ b/S1_NRB/tile_extraction.py
@@ -200,8 +200,12 @@ def aoi_from_scene(scene, kml, multi=True, percent=1):
         # extract all overlapping tiles
         with scene.geometry() as geom:
             tiles = tile_from_aoi(vector=geom, kml=kml, return_geometries=True)
+        
         # group tiles by UTM zone
-        for zone, group in itertools.groupby(tiles, lambda x: x.mgrs[:2]):
+        def fn(x):
+            return x.getProjection(type='epsg')
+        
+        for zone, group in itertools.groupby(tiles, lambda x: fn(x)):
             geometries = list(group)
             # get UTM EPSG code
             epsg = geometries[0].getProjection(type='epsg')


### PR DESCRIPTION
The function [tile_extraction.aoi_from_scene](https://s1-nrb.readthedocs.io/en/latest/api.html#S1_NRB.tile_extraction.aoi_from_scene) did not differentiate between North and South hemisphere leading to incomplete processing results. With this, the two hemispheres are separated and hence processed separately.