### PR TITLE
[processor] fixed 'empty selection' message

### DIFF
--- a/S1_NRB/processor.py
+++ b/S1_NRB/processor.py
@@ -74,13 +74,13 @@ def main(config_file, section_name='PROCESSING', debug=False, **kwargs):
         msg = "No scenes could be found for the following search query:\n" \
               " sensor:       '{sensor}'\n" \
               " product:      '{product}'\n" \
-              " acq. mode:    '{acq_mode}'\n" \
+              " acq_mode:     '{acquisition_mode}'\n" \
               " aoi_tiles:    '{aoi_tiles}'\n" \
               " aoi_geometry: '{aoi_geometry}'\n" \
               " mindate:      '{mindate}'\n" \
               " maxdate:      '{maxdate}'\n" \
               " date_strict:  '{date_strict}'\n" \
-              " datatake:     '{datatake}'\n"
+              " datatake:     '{frameNumber}'\n"
         print(msg.format(**dict_search))
         archive.close()
         return


### PR DESCRIPTION
This fixes errors that occurred while formatting the selection message with the wrong dictionary keys.