### PR TITLE
use file locking for SNAP processing

### DIFF
--- a/S1_NRB/ancillary.py
+++ b/S1_NRB/ancillary.py
@@ -363,8 +363,8 @@ class Lock(object):
 
 
 class LockCollection(object):
-    def __init__(self, targets, timeout=7200):
-        self.locks = [Lock(x, soft=True, timeout=timeout) for x in targets]
+    def __init__(self, targets, soft=False, timeout=7200):
+        self.locks = [Lock(x, soft=soft, timeout=timeout) for x in targets]
     
     def __enter__(self):
         return self

--- a/S1_NRB/ancillary.py
+++ b/S1_NRB/ancillary.py
@@ -331,10 +331,10 @@ class Lock(object):
                 raise RuntimeError(msg.format(self.target))
             try:
                 if self.soft and not os.path.isfile(self.lock):
-                    Path(self.used, exist_ok=True).touch()
+                    Path(self.used).touch(exist_ok=False)
                     break
                 if not self.soft and not self.is_used():
-                    Path(self.lock, exist_ok=False).touch()
+                    Path(self.lock).touch(exist_ok=False)
                     break
             except FileExistsError:
                 pass

--- a/S1_NRB/ancillary.py
+++ b/S1_NRB/ancillary.py
@@ -1,10 +1,8 @@
 import os
 import sys
-import time
 import logging
 import binascii
 from lxml import etree
-from pathlib import Path
 from datetime import datetime, timedelta
 from osgeo import gdal
 import spatialist
@@ -304,74 +302,6 @@ def log(handler, mode, proc_step, scenes, msg):
         handler.exception(message)
     else:
         raise RuntimeError('log mode {} is not supported'.format(mode))
-
-
-class Lock(object):
-    def __init__(self, target, soft=False, timeout=7200):
-        if os.path.isdir(target) and not os.path.exists(target):
-            raise OSError('target does not exist: {}'.format(target))
-        self.target = target
-        used_id = generate_unique_id(str(time.time()).encode())
-        if os.path.isdir(target):
-            self.lock = os.path.join(self.target, 'LOCK')
-            self.error = os.path.join(self.target, 'ERROR')
-            self.used = os.path.join(self.target, f'USED_{used_id}')
-        else:
-            self.lock = self.target + '.lock'
-            self.error = self.target + '.error'
-            self.used = self.target + f'.used_{used_id}'
-        self.soft = soft
-        if os.path.isfile(self.error):
-            msg = 'cannot acquire lock on damaged target: {}'
-            raise RuntimeError(msg.format(self.target))
-        end = time.time() + timeout
-        while True:
-            if time.time() > end:
-                msg = 'could not acquire lock due to timeout: {}'
-                raise RuntimeError(msg.format(self.target))
-            try:
-                if self.soft and not os.path.isfile(self.lock):
-                    Path(self.used).touch(exist_ok=False)
-                    break
-                if not self.soft and not self.is_used():
-                    Path(self.lock).touch(exist_ok=False)
-                    break
-            except FileExistsError:
-                pass
-            time.sleep(1)
-    
-    def __enter__(self):
-        return self
-    
-    def __exit__(self, exc_type, exc_value, traceback):
-        if not self.soft and exc_type is not None:
-            os.rename(self.lock, self.error)
-        else:
-            self.remove()
-    
-    def is_used(self):
-        base = os.path.basename(self.used)
-        folder = os.path.dirname(self.used)
-        files = list(Path(folder).glob(base[:-4] + '*'))
-        return len(files) > 0
-    
-    def remove(self):
-        if self.soft:
-            os.remove(self.used)
-        else:
-            os.remove(self.lock)
-
-
-class LockCollection(object):
-    def __init__(self, targets, soft=False, timeout=7200):
-        self.locks = [Lock(x, soft=soft, timeout=timeout) for x in targets]
-    
-    def __enter__(self):
-        return self
-    
-    def __exit__(self, exc_type, exc_value, traceback):
-        for lock in self.locks:
-            lock.remove()
 
 
 def vrt_add_overviews(vrt, overviews, resampling='AVERAGE'):

--- a/S1_NRB/snap.py
+++ b/S1_NRB/snap.py
@@ -18,7 +18,7 @@ from pyroSAR.snap.auxil import gpt, parse_recipe, parse_node, \
     orb_parametrize, mli_parametrize, geo_parametrize, \
     sub_parametrize, erode_edges
 from S1_NRB.tile_extraction import aoi_from_scene
-from S1_NRB.ancillary import Lock, LockCollection
+from pyroSAR.ancillary import Lock, LockCollection
 
 
 def mli(src, dst, workflow, spacing=None, rlks=None, azlks=None, gpt_args=None):

--- a/S1_NRB/snap.py
+++ b/S1_NRB/snap.py
@@ -688,7 +688,7 @@ def process(scene, outdir, measurement, spacing, kml, dem,
         workflows.append(out_buffer_wf)
         if not os.path.isfile(out_buffer):
             print('### buffering scene with neighboring acquisitions')
-            with LockCollection(out_pre_neighbors):
+            with LockCollection(out_pre_neighbors, soft=True):
                 grd_buffer(src=out_pre, dst=out_buffer, workflow=out_buffer_wf,
                            neighbors=out_pre_neighbors, gpt_args=gpt_args,
                            buffer=10 * spacing)

--- a/S1_NRB/snap.py
+++ b/S1_NRB/snap.py
@@ -99,7 +99,7 @@ def pre(src, dst, workflow, allow_res_osv=True, osv_continue_on_fail=False,
         output beta nought backscatter needed for RTC?
     output_sigma0: bool
         output sigma nought backscatter needed for NESZ?
-    output_gama0: bool
+    output_gamma0: bool
         output gamma nought backscatter needed?
     gpt_args: list[str] or None
         a list of additional arguments to be passed to the gpt call

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -13,7 +13,7 @@ dependencies:
   - pystac>=1.8.0
   - pystac-client>=0.7.0
   - scipy
-  - pyroSAR>=0.23.0
+  - pyroSAR>=0.25.0
   - spatialist>=0.12.0
   - s1etad>=0.5.3
   - s1etad_tools>=0.8.1

--- a/environment.yaml
+++ b/environment.yaml
@@ -13,7 +13,7 @@ dependencies:
   - pystac>=1.8.0
   - pystac-client>=0.7.0
   - scipy
-  - pyroSAR>=0.23.0
+  - pyroSAR>=0.25.0
   - spatialist>=0.12.0
   - s1etad>=0.5.3
   - s1etad_tools>=0.8.1

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
                       'click>=7.1.0',
                       'lxml',
                       'pystac>=1.8.0',
-                      'pyroSAR>=0.23.0',
+                      'pyroSAR>=0.25.0',
                       'spatialist>=0.12.0',
                       'scipy',
                       's1etad>=0.5.3',


### PR DESCRIPTION
Apply [pyroSAR.ancillary.Lock](https://pyrosar.readthedocs.io/en/latest/api/ancillary.html#pyroSAR.ancillary.Lock) during SAR preprocessing and GRD buffering. This enables processing neighboring GRDs in parallel, which depend on each other for buffering.  
This significantly increases SAR processing scalability using configuration parameter `scene`. However, file locking is not yet applied to all created files and race conditions might still occur.