### PR TITLE
inherit pyroSAR SceneArchive interfacing protocol, bug fixes

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -13,7 +13,7 @@ dependencies:
   - pandas
   - pip
   - pyproj
-  - pyroSAR>=0.33.2
+  - pyroSAR>=0.35.0
   - pystac>=1.8.0,<1.11.0
   - pystac-client>=0.7.0
   - python>=3.10

--- a/environment.yaml
+++ b/environment.yaml
@@ -13,7 +13,7 @@ dependencies:
   - pandas
   - pip
   - pyproj
-  - pyroSAR>=0.33.2
+  - pyroSAR>=0.35.0
   - pystac>=1.8.0,<1.11.0
   - pystac-client>=0.7.0
   - python>=3.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ numpy
 packaging
 pandas
 pyproj
-pyroSAR>=0.33.2
+pyroSAR>=0.35.0
 pystac>=1.8.0,<1.11.0
 pystac-client>=0.7.0
 python-dateutil

--- a/s1ard/ard.py
+++ b/s1ard/ard.py
@@ -512,10 +512,6 @@ def append_metadata(
         the wind model reference wind speed files
     wm_ref_direction:
         the wind model reference wind direction files
-
-    Returns
-    -------
-
     """
     meta = meta_dict(config=config, prod_meta=prod_meta,
                      src_ids=src_ids, compression=compression)
@@ -589,11 +585,11 @@ def get_datasets(
         that overlap with the current MGRS tile and a list of SAR processing output
         files that match each :class:`~pyroSAR.drivers.ID` object of `ids`.
         The format of the latter is a list of dictionaries per scene with keys as
-        described by e.g. :func:`s1ard.snap.find_datasets`.
+        described by e.g. :func:`cesard.snap.find_datasets`.
     
     See Also
     --------
-    :func:`s1ard.snap.find_datasets`
+    :func:`cesard.snap.find_datasets`
     """
     processor = load_processor(processor_name)
     ids = identify_many(scenes, sortkey='start')
@@ -717,10 +713,6 @@ def wind_normalization(
         The target pixel resolution in meters. 915 is chosen as default because
         it is closest to the OCN product resolution (1000) and still fits into
         the MGRS bounds (``109800 % 915 == 0``).
-    
-    Returns
-    -------
-    
     """
     if len(src) > 1:
         cmod_mosaic = get_tmp_name(suffix='.tif')

--- a/s1ard/processor.py
+++ b/s1ard/processor.py
@@ -8,8 +8,7 @@ from spatialist.ancillary import finder
 from pyroSAR import identify, identify_many, Archive
 from s1ard.config import get_config, gdal_conf
 from s1ard.ancillary import set_logging
-from s1ard import search
-from s1ard import ocn
+from s1ard import ard, ocn, search
 from cesard import dem
 import cesard.tile_extraction as tile_ex
 from cesard.search import scene_select

--- a/s1ard/search.py
+++ b/s1ard/search.py
@@ -1,16 +1,23 @@
+from __future__ import annotations
+
 import os
 import re
 import pandas as pd
 from pathlib import Path
+from datetime import datetime
 from dateutil.parser import parse as dateparse
 from packaging.version import Version
 from pystac_client import Client
 from pystac_client.stac_api_io import StacApiIO
 from spatialist.vector import Vector
 from shapely.geometry import shape
-from pyroSAR import identify_many
+from pyroSAR import ID, identify_many, Archive
 from cesard.ancillary import date_to_utc, buffer_time
-from cesard.search import asf_select
+from cesard.search import asf_select, ASFArchive
+
+from types import TracebackType
+from typing import Any
+
 import logging
 
 log = logging.getLogger('s1ard')
@@ -20,19 +27,18 @@ class STACArchive(object):
     """
     Search for scenes in a SpatioTemporal Asset Catalog.
     Scenes are expected to be unpacked with a folder suffix .SAFE.
-    The interface is kept consistent with :class:`~s1ard.search.ASFArchive`,
-    :class:`~s1ard.search.STACParquetArchive` and :class:`pyroSAR.drivers.Archive`.
     
     Parameters
     ----------
-    url: str
+    url:
         the catalog URL
-    collections: str or list[str]
+    collections:
         the catalog collection(s) to be searched
-    timeout: int
+    timeout:
         the allowed timeout in seconds
-    max_retries: int or None
-        the number of times to retry requests. Set to None to disable retries.
+    max_retries:
+        the number of times to retry requests.
+        Set to `None` to disable retries.
     
     See Also
     --------
@@ -40,7 +46,13 @@ class STACArchive(object):
     pystac_client.stac_api_io.StacApiIO
     """
     
-    def __init__(self, url, collections, timeout=60, max_retries=20):
+    def __init__(
+            self,
+            url: str,
+            collections: str | list[str],
+            timeout: int = 60,
+            max_retries: int | None = 20
+    ) -> None:
         self.url = url
         self.timeout = timeout
         self.max_tries = max_retries
@@ -52,13 +64,19 @@ class STACArchive(object):
         else:
             raise TypeError("'collections' must be of type str or list")
     
-    def __enter__(self):
+    def __enter__(self) -> STACArchive:
         return self
     
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc_val: BaseException | None,
+            exc_tb: TracebackType | None
+    ) -> None:
         self.close()
     
-    def _filter_duplicates(self, values):
+    @staticmethod
+    def _filter_duplicates(values: list[Any]) -> list[Any]:
         tmp = sorted(values, key=lambda x: os.path.basename(x[-2]))
         pattern = '([0-9A-Z_]{16})_([0-9T]{15})_([0-9T]{15})'
         keep = []
@@ -84,19 +102,28 @@ class STACArchive(object):
             i = j
         return keep
     
-    def _open_catalog(self):
+    def _open_catalog(self) -> None:
         stac_api_io = StacApiIO(max_retries=self.max_tries)
         self.catalog = Client.open(url=self.url,
                                    stac_io=stac_api_io,
                                    timeout=self.timeout)
     
-    def close(self):
+    def close(self) -> None:
         del self.catalog
     
-    def select(self, sensor=None, product=None, acquisition_mode=None,
-               mindate=None, maxdate=None, frameNumber=None,
-               vectorobject=None, date_strict=True, check_exist=True,
-               return_value="scene"):
+    def select(
+            self,
+            sensor: str | list[str] | None = None,
+            product: str | list[str] | None = None,
+            acquisition_mode: str | list[str] | None = None,
+            mindate: str | datetime | None = None,
+            maxdate: str | datetime | None = None,
+            frameNumber: int | str | list[int | str] | None = None,
+            vectorobject: Vector | None = None,
+            date_strict: bool = True,
+            check_exist: bool = True,
+            return_value: str | list[str] = "scene"
+    ) -> list[str | bytes] | list[tuple[str | bytes]]:
         """
         Select scenes from the catalog. Duplicates (same acquisition time) are filtered
         by returning only the last processed product. Used STAC property keys:
@@ -111,30 +138,30 @@ class STACArchive(object):
 
         Parameters
         ----------
-        sensor: str or list[str] or None
+        sensor:
             S1A | S1B | S1C | S1D
-        product: str or list[str] or None
+        product:
             GRD | SLC
-        acquisition_mode: str or list[str] or None
+        acquisition_mode:
             IW | EW | SM
-        mindate: str or datetime.datetime or None
+        mindate:
             the minimum acquisition date; timezone-unaware dates are interpreted as UTC.
-        maxdate: str or datetime.datetime or None
+        maxdate:
             the maximum acquisition date; timezone-unaware dates are interpreted as UTC.
-        frameNumber: int or str or list[int or str] or None
+        frameNumber:
             the data take ID in decimal (int) or hexadecimal (str) representation.
             Requires custom STAC key `s1:datatake`.
-        vectorobject: spatialist.vector.Vector or None
+        vectorobject:
             a geometry with which the scenes need to overlap. The object may only contain one feature.
-        date_strict: bool
+        date_strict:
             treat dates as strict limits or also allow flexible limits to incorporate scenes
             whose acquisition period overlaps with the defined limit?
 
             - strict: start >= mindate & stop <= maxdate
             - not strict: stop >= mindate & start <= maxdate
-        check_exist: bool
+        check_exist:
             check whether found files exist locally?
-        return_value: str or List[str]
+        return_value:
             the query return value(s). Options:
             
             - acquisition_mode: the sensor's acquisition mode, e.g., IW, EW, SM
@@ -149,7 +176,6 @@ class STACArchive(object):
 
         Returns
         -------
-        list or list[tuple]
             If a single return_value is specified: list of values
             If multiple return_values are specified: list of tuples containing the requested values
 
@@ -178,7 +204,7 @@ class STACArchive(object):
             'S1A': 'sentinel-1a',
             'S1B': 'sentinel-1b',
             'S1C': 'sentinel-1c',
-            'S1D': 'sentinel-1Dd'
+            'S1D': 'sentinel-1d'
         }
         lookup_platform_reverse = {value: key for key, value
                                    in lookup_platform.items()}
@@ -298,28 +324,33 @@ class STACParquetArchive(object):
 
     Parameters
     ----------
-    files: str
+    files:
         the file search pattern, e.g. `/path/to/*parquet`
     """
     
-    def __init__(self, files):
+    def __init__(self, files: str) -> None:
         self.files = files
     
-    def __enter__(self):
+    def __enter__(self) -> STACParquetArchive:
         return self
     
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc_val: BaseException | None,
+            exc_tb: TracebackType | None
+    ) -> None:
         return
     
     @staticmethod
-    def _filter_antimeridian(df):
+    def _filter_antimeridian(df: pd.DataFrame) -> pd.DataFrame:
         # The geometry of scenes crossing the antimeridian is stored as multipolygon.
         out = df[df["geometry_wkt"].str.startswith("POLYGON")]
         if len(out) < len(df):
             log.debug(f'removed {len(df) - len(out)} '
                       f'scene(s) crossing the antimeridian')
         return out
-        
+    
     @staticmethod
     def _filter_duplicates(values: pd.DataFrame) -> pd.DataFrame:
         """
@@ -508,13 +539,23 @@ class STACParquetArchive(object):
         log.debug(f"removed {len(to_drop)} duplicate(s)")
         return out
     
-    def close(self):
+    def close(self) -> None:
         pass
     
-    def select(self, sensor=None, product=None, acquisition_mode=None,
-               mindate=None, maxdate=None, frameNumber=None,
-               vectorobject=None, date_strict=True, return_value='scene',
-               filter_antimeridian=True, filter_duplicates=True):
+    def select(
+            self,
+            sensor: str | list[str] | None = None,
+            product: str | list[str] | None = None,
+            acquisition_mode: str | list[str] | None = None,
+            mindate: str | datetime | None = None,
+            maxdate: str | datetime | None = None,
+            frameNumber: int | str | list[int | str] | None = None,
+            vectorobject: Vector | None = None,
+            date_strict: bool = True,
+            return_value: str | list[str] = 'scene',
+            filter_antimeridian: bool = True,
+            filter_duplicates: bool = True
+    ) -> list[str | bytes] | list[tuple[str | bytes]]:
         """
         Select scenes from a STAC catalog's geoparquet dump. Used STAC property keys:
 
@@ -530,28 +571,28 @@ class STACParquetArchive(object):
 
         Parameters
         ----------
-        sensor: str or list[str] or None
+        sensor:
             S1A | S1B | S1C | S1D
-        product: str or list[str] or None
+        product:
             GRD | SLC
-        acquisition_mode: str or list[str] or None
+        acquisition_mode:
             IW | EW | SM
-        mindate: str or datetime.datetime or None
+        mindate:
             the minimum acquisition date; timezone-unaware dates are interpreted as UTC.
-        maxdate: str or datetime.datetime or None
+        maxdate:
             the maximum acquisition date; timezone-unaware dates are interpreted as UTC.
-        frameNumber: int or str or list[int or str] or None
+        frameNumber:
             the data take ID in decimal (int) or hexadecimal (str) representation.
             Requires custom STAC key `s1:datatake`.
-        vectorobject: spatialist.vector.Vector or None
+        vectorobject:
             a geometry with which the scenes need to overlap
-        date_strict: bool
+        date_strict:
             treat dates as strict limits or also allow flexible limits to incorporate scenes
             whose acquisition period overlaps with the defined limit?
 
             - strict: start >= mindate & stop <= maxdate
             - not strict: stop >= mindate & start <= maxdate
-        return_value: str or List[str]
+        return_value:
             the query return value(s). Options:
             
             - acquisition_mode: the sensor's acquisition mode, e.g., IW, EW, SM
@@ -566,14 +607,13 @@ class STACParquetArchive(object):
             - slice_number: the slice number (position) in the datatake
             - total_slices: the number of slices (products) in the datatake
             - processing_date: the processing datetime in UTC formatted as YYYYmmddTHHMMSS
-        filter_antimeridian: bool
+        filter_antimeridian:
             remove scenes crossing the antimeridian
-        filter_duplicates: bool
+        filter_duplicates:
             Sentinel-1 scenes are often reprocessed. With this, duplicates can be filtered out.
 
         Returns
         -------
-        List[str] or List[tuple[str]]
             the selected return value(s). Depending on whether a single or multiple
             values have been defined for `return_value`, the returned list will
             contain strings or tuples.
@@ -715,22 +755,28 @@ class STACParquetArchive(object):
             return list(result.itertuples(index=False, name=None))
 
 
-def collect_neighbors(archive, scene, stac_check_exist=True):
+SceneArchive = Archive | STACArchive | STACParquetArchive | ASFArchive
+
+
+def collect_neighbors(
+        archive: SceneArchive,
+        scene: ID,
+        stac_check_exist: bool = True
+) -> list[str]:
     """
     Collect a scene's neighboring acquisitions in a data take.
     
     Parameters
     ----------
-    archive: pyroSAR.drivers.Archive or STACArchive or STACParquetArchive or ASFArchive
+    archive:
         an open scene archive connection
-    scene: pyroSAR.drivers.ID
+    scene:
         the Sentinel-1 scene to be checked
-    stac_check_exist: bool
+    stac_check_exist:
         if `archive` is of type :class:`STACArchive`, check the local existence of the scenes?
 
     Returns
     -------
-    list[str]
         the filenames/URLs of the neighboring scenes
     """
     start, stop = buffer_time(scene.start, scene.stop, seconds=2)
@@ -763,7 +809,10 @@ def collect_neighbors(archive, scene, stac_check_exist=True):
     return neighbors
 
 
-def check_acquisition_completeness(archive, scenes):
+def check_acquisition_completeness(
+        archive: SceneArchive,
+        scenes: list[ID]
+) -> None:
     """
     Check presence of neighboring acquisitions.
     Check that for each scene a predecessor and successor can be queried
@@ -777,13 +826,10 @@ def check_acquisition_completeness(archive, scenes):
 
     Parameters
     ----------
-    archive: pyroSAR.drivers.Archive or STACArchive
+    archive:
         an open scene archive connection
-    scenes: list[pyroSAR.drivers.ID]
+    scenes:
         a list of scenes
-
-    Returns
-    -------
 
     Raises
     ------

--- a/s1ard/search.py
+++ b/s1ard/search.py
@@ -11,9 +11,10 @@ from pystac_client import Client
 from pystac_client.stac_api_io import StacApiIO
 from spatialist.vector import Vector
 from shapely.geometry import shape
-from pyroSAR import ID, identify_many, Archive
+from pyroSAR import ID, identify_many
+from pyroSAR.archive import SceneArchive
 from cesard.ancillary import date_to_utc, buffer_time
-from cesard.search import asf_select, ASFArchive
+from cesard.search import asf_select
 
 from types import TracebackType
 from typing import Any
@@ -23,7 +24,7 @@ import logging
 log = logging.getLogger('s1ard')
 
 
-class STACArchive(object):
+class STACArchive(SceneArchive):
     """
     Search for scenes in a SpatioTemporal Asset Catalog.
     Scenes are expected to be unpacked with a folder suffix .SAFE.
@@ -118,11 +119,11 @@ class STACArchive(object):
             acquisition_mode: str | list[str] | None = None,
             mindate: str | datetime | None = None,
             maxdate: str | datetime | None = None,
-            frameNumber: int | str | list[int | str] | None = None,
             vectorobject: Vector | None = None,
             date_strict: bool = True,
+            return_value: str | list[str] = "scene",
+            frameNumber: int | str | list[int | str] | None = None,
             check_exist: bool = True,
-            return_value: str | list[str] = "scene"
     ) -> list[str | bytes] | list[tuple[str | bytes]]:
         """
         Select scenes from the catalog. Duplicates (same acquisition time) are filtered
@@ -148,9 +149,6 @@ class STACArchive(object):
             the minimum acquisition date; timezone-unaware dates are interpreted as UTC.
         maxdate:
             the maximum acquisition date; timezone-unaware dates are interpreted as UTC.
-        frameNumber:
-            the data take ID in decimal (int) or hexadecimal (str) representation.
-            Requires custom STAC key `s1:datatake`.
         vectorobject:
             a geometry with which the scenes need to overlap. The object may only contain one feature.
         date_strict:
@@ -159,8 +157,6 @@ class STACArchive(object):
 
             - strict: start >= mindate & stop <= maxdate
             - not strict: stop >= mindate & start <= maxdate
-        check_exist:
-            check whether found files exist locally?
         return_value:
             the query return value(s). Options:
             
@@ -173,7 +169,12 @@ class STACArchive(object):
             - product: the product type, e.g., SLC, GRD
             - scene: the scene's storage location path (default)
             - sensor: the satellite platform, e.g., S1A or S1B
-
+        frameNumber:
+            the data take ID in decimal (int) or hexadecimal (str) representation.
+            Requires custom STAC key `s1:datatake`.
+        check_exist:
+            check whether found files exist locally?
+        
         Returns
         -------
             If a single return_value is specified: list of values
@@ -315,7 +316,7 @@ class STACArchive(object):
         return out
 
 
-class STACParquetArchive(object):
+class STACParquetArchive(SceneArchive):
     """
     Search for scenes in STAC geoparquet dump.
     Scenes are expected to be unpacked with a folder suffix .SAFE.
@@ -549,10 +550,10 @@ class STACParquetArchive(object):
             acquisition_mode: str | list[str] | None = None,
             mindate: str | datetime | None = None,
             maxdate: str | datetime | None = None,
-            frameNumber: int | str | list[int | str] | None = None,
             vectorobject: Vector | None = None,
             date_strict: bool = True,
             return_value: str | list[str] = 'scene',
+            frameNumber: int | str | list[int | str] | None = None,
             filter_antimeridian: bool = True,
             filter_duplicates: bool = True
     ) -> list[str | bytes] | list[tuple[str | bytes]]:
@@ -581,9 +582,6 @@ class STACParquetArchive(object):
             the minimum acquisition date; timezone-unaware dates are interpreted as UTC.
         maxdate:
             the maximum acquisition date; timezone-unaware dates are interpreted as UTC.
-        frameNumber:
-            the data take ID in decimal (int) or hexadecimal (str) representation.
-            Requires custom STAC key `s1:datatake`.
         vectorobject:
             a geometry with which the scenes need to overlap
         date_strict:
@@ -607,6 +605,9 @@ class STACParquetArchive(object):
             - slice_number: the slice number (position) in the datatake
             - total_slices: the number of slices (products) in the datatake
             - processing_date: the processing datetime in UTC formatted as YYYYmmddTHHMMSS
+        frameNumber:
+            the data take ID in decimal (int) or hexadecimal (str) representation.
+            Requires custom STAC key `s1:datatake`.
         filter_antimeridian:
             remove scenes crossing the antimeridian
         filter_duplicates:
@@ -753,9 +754,6 @@ class STACParquetArchive(object):
             return list(result.iloc[:, 0])
         else:
             return list(result.itertuples(index=False, name=None))
-
-
-SceneArchive = Archive | STACArchive | STACParquetArchive | ASFArchive
 
 
 def collect_neighbors(

--- a/s1ard/search.py
+++ b/s1ard/search.py
@@ -320,8 +320,6 @@ class STACParquetArchive(SceneArchive):
     """
     Search for scenes in STAC geoparquet dump.
     Scenes are expected to be unpacked with a folder suffix .SAFE.
-    The interface is kept consistent with :class:`~s1ard.search.ASFArchive`,
-    :class:`~s1ard.search.STACArchive` and :class:`pyroSAR.drivers.Archive`.
 
     Parameters
     ----------


### PR DESCRIPTION
pyroSAR 0.35.0 introduced a new protocol class [SceneArchive](https://pyrosar.readthedocs.io/en/latest/api/archive.html#pyroSAR.archive.SceneArchive). This class is now inherited by classes `search.STACArchive` and `search.STACParquetArchive`.

Furthermore
- some typing was added
- links corrected in docstrings
- the missing module `s1ard.ard` imported in `processor` (bugfix)
- `search.STACArchive.select` fixed typo in `lookup_platform` value (bugfix)